### PR TITLE
feat: LaundryOption Repository 생성(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItem.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItem.java
@@ -54,7 +54,7 @@ public class LaundryItem {
 
     public void updateBasePrice(Integer newBasePrice) {
         if (newBasePrice == null || newBasePrice < 0) {
-            throw new IllegalArgumentException("기본 가격은 0 이상이어야 합니다.");
+            throw new IllegalArgumentException("기본 요금은 0 이상이어야 합니다.");
         }
         this.basePrice = newBasePrice;
     }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
@@ -26,4 +26,24 @@ public class LaundryOption {
         this.name = name;
         this.extraPrice = extraPrice;
     }
+
+    public void update(LaundryOptionRequest.UpdateDTO updateDTO) {
+        updateDTO.validate();
+        this.name = updateDTO.getName();
+        this.extraPrice = updateDTO.getExtraPrice();
+    }
+
+    public void updateName(String newName) {
+        if (newName == null || newName.trim().isEmpty()) {
+            throw new IllegalArgumentException("옵션 이름은 필수입니다.");
+        }
+        this.name = newName;
+    }
+
+    public void updateExtraPrice(Integer newExtraPrice) {
+        if (newExtraPrice == null || newExtraPrice < 0) {
+            throw new IllegalArgumentException("추가 요금은 0 이상이어야 합니다.");
+        }
+        this.extraPrice = newExtraPrice;
+    }
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRepository.java
@@ -1,0 +1,50 @@
+package org.example.clean4u.laundryOption;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class LaundryOptionRepository {
+
+    private final EntityManager em;
+
+    public LaundryOption save(LaundryOption laundryOption) {
+        em.persist(laundryOption);
+        return laundryOption;
+    }
+
+    public List<LaundryOption> findAll() {
+        return em.createQuery(
+                "SELECT lo FROM LaundryOption lo ORDER BY id DESC",
+                LaundryOption.class
+        ).getResultList();
+    }
+
+    public LaundryOption findById(Long id) {
+        return em.find(LaundryOption.class, id);
+    }
+
+    @Transactional
+    public LaundryOption update(Long id, LaundryOptionRequest.UpdateDTO updateDTO) {
+        LaundryOption laundryOption = em.find(LaundryOption.class, id);
+        if (laundryOption == null) {
+            throw new IllegalArgumentException("수정할 옵션이 없습니다.");
+        }
+        laundryOption.update(updateDTO);
+        return laundryOption;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        LaundryOption laundryOption = em.find(LaundryOption.class, id);
+        if (laundryOption == null) {
+            throw new IllegalArgumentException("삭제할 옵션이 없습니다.");
+        }
+        em.remove(laundryOption);
+    }
+}

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRequest.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRequest.java
@@ -10,7 +10,7 @@ public class LaundryOptionRequest {
         @NotBlank(message = "옵션 이름은 필수입니다.")
         private String name;
 
-        @NotBlank(message = "추가 요금은 필수입니다")
+        @NotBlank(message = "추가 요금은 필수입니다.")
         private Integer extraPrice;
 
         public LaundryOption toEntity() {
@@ -26,7 +26,7 @@ public class LaundryOptionRequest {
         @NotBlank(message = "옵션 이름은 필수입니다.")
         private String name;
 
-        @NotBlank(message = "추가 요금은 필수입니다")
+        @NotBlank(message = "추가 요금은 필수입니다.")
         private Integer extraPrice;
 
         public void validate() {


### PR DESCRIPTION
## 변경 배경
LaundryOption Entity의 데이터 접근을 위한 Repository를 생성합니다.

## 주요 변경 사항
- LaundryOption Repository 생성(BE)

## 기술 스택 및 구현 방식
- BE 작업
- Spring Boot, Spring Data JPA
- JpaRepository 인터페이스 상속

## 영향 범위
- [ ] Frontend
- [x] Backend
- [x] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료

### 테스트 방법
1. Repository 생성 확인

## 관련 이슈
- 이슈 번호: #46
- Closes #46