### PR TITLE
feat: SupplyItem Repository 생성(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItem.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItem.java
@@ -30,4 +30,32 @@ public class SupplyItem {
         this.unit = unit;
         this.stockQuantity = stockQuantity;
     }
+
+    public void update(SupplyItemRequest.UpdateDTO updateDTO) {
+        updateDTO.validate();
+        this.name = updateDTO.getName();
+        this.unit = updateDTO.getUnit();
+        this.stockQuantity = updateDTO.getStockQuantity();
+    }
+
+    public void updateName(String newName) {
+        if (newName == null || newName.trim().isEmpty()) {
+            throw new IllegalArgumentException("자재 이름은 필수입니다.");
+        }
+        this.name = newName;
+    }
+
+    public void updateUnit(String newUnit) {
+        if (newUnit == null || newUnit.trim().isEmpty()) {
+            throw new IllegalArgumentException("단위는 필수입니다.");
+        }
+        this.unit = newUnit;
+    }
+
+    public void updateStockQuantity(Integer newStockQuantity) {
+        if (newStockQuantity == null || newStockQuantity < 0) {
+            throw new IllegalArgumentException("재고 수량은 0 이상 이어야 합니다.");
+        }
+        this.stockQuantity = newStockQuantity;
+    }
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRepository.java
@@ -1,0 +1,50 @@
+package org.example.clean4u.supplyItem;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SupplyItemRepository {
+
+    private final EntityManager em;
+
+    public SupplyItem save(SupplyItem supplyItem) {
+        em.persist(supplyItem);
+        return supplyItem;
+    }
+
+    public List<SupplyItem> findAll() {
+        return em.createQuery(
+                "SELECT si FROM SupplyItem si ORDER BY si.id DESC",
+                SupplyItem.class
+        ).getResultList();
+    }
+
+    public SupplyItem findById(Long id) {
+        return em.find(SupplyItem.class, id);
+    }
+
+    @Transactional
+    public SupplyItem update(Long id, SupplyItemRequest.UpdateDTO updateDTO) {
+        SupplyItem supplyItem = em.find(SupplyItem.class, id);
+        if (supplyItem == null) {
+            throw new IllegalArgumentException("수정할 자재가 없습니다.");
+        }
+        supplyItem.update(updateDTO);
+        return supplyItem;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        SupplyItem supplyItem = em.find(SupplyItem.class, id);
+        if (supplyItem == null) {
+            throw new IllegalArgumentException("삭제할 자재가 없습니다.");
+        }
+        em.remove(supplyItem);
+    }
+}


### PR DESCRIPTION
## 변경 배경
SupplyItem Entity의 데이터 접근을 위한 Repository를 생성합니다.

## 주요 변경 사항
- SupplyItem Repository 생성(BE)

## 기술 스택 및 구현 방식
- BE 작업
- Spring Boot, Spring Data JPA
- JpaRepository 인터페이스 상속

## 영향 범위
- [ ] Frontend
- [x] Backend
- [x] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료

### 테스트 방법
1. Repository 생성 확인

## 관련 이슈
- 이슈 번호: #48
- Closes #48