### PR TITLE
feat: LaundryOption 상세 정보 확장(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
@@ -24,18 +24,23 @@ public class LaundryOption {
     @Column(name = "description")
     private String description;
 
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
     @Builder
-    public LaundryOption(Long id, String name, Integer extraPrice, String description) {
+    public LaundryOption(Long id, String name, Integer extraPrice, String description, Boolean isActive) {
         this.id = id;
         this.name = name;
         this.extraPrice = extraPrice;
         this.description = description;
+        this.isActive = isActive != null ? isActive : true;
     }
 
     public void update(LaundryOptionRequest.UpdateDTO updateDTO) {
         this.name = updateDTO.getName();
         this.extraPrice = updateDTO.getExtraPrice();
         this.description = updateDTO.getDescription();
+        this.isActive = updateDTO.getIsActive();
     }
 
     public void updateName(String newName) {
@@ -54,5 +59,9 @@ public class LaundryOption {
 
     public void updateDescription(String newDescription) {
         this.description = newDescription;
+    }
+
+    public void updateIsActive(Boolean newIsActive) {
+        this.isActive = newIsActive;
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
@@ -21,16 +21,21 @@ public class LaundryOption {
     @Column(name = "extra_price", nullable = false)
     private Integer extraPrice;
 
+    @Column(name = "description")
+    private String description;
+
     @Builder
-    public LaundryOption(Long id, String name, Integer extraPrice) {
+    public LaundryOption(Long id, String name, Integer extraPrice, String description) {
         this.id = id;
         this.name = name;
         this.extraPrice = extraPrice;
+        this.description = description;
     }
 
     public void update(LaundryOptionRequest.UpdateDTO updateDTO) {
         this.name = updateDTO.getName();
         this.extraPrice = updateDTO.getExtraPrice();
+        this.description = updateDTO.getDescription();
     }
 
     public void updateName(String newName) {
@@ -45,5 +50,9 @@ public class LaundryOption {
             throw new IllegalArgumentException("추가 요금은 0 이상이어야 합니다.");
         }
         this.extraPrice = newExtraPrice;
+    }
+
+    public void updateDescription(String newDescription) {
+        this.description = newDescription;
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
@@ -4,12 +4,13 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.example.clean4u.time.BaseTimeEntity;
 
 @NoArgsConstructor
 @Data
 @Entity
 @Table(name = "laundry_option_tb")
-public class LaundryOption {
+public class LaundryOption extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "laundry_option_id")

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRequest.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRequest.java
@@ -16,10 +16,13 @@ public class LaundryOptionRequest {
         @Min(value = 0, message = "추가 요금은 0 이상 이어야 합니다.")
         private Integer extraPrice;
 
+        private String description;
+
         public LaundryOption toEntity() {
             return LaundryOption.builder()
                     .name(name)
                     .extraPrice(extraPrice)
+                    .description(description)
                     .build();
         }
     }
@@ -32,5 +35,7 @@ public class LaundryOptionRequest {
         @NotNull(message = "추가 요금은 필수입니다.")
         @Min(value = 0, message = "추가 요금은 0 이상 이어야 합니다.")
         private Integer extraPrice;
+
+        private String description;
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRequest.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRequest.java
@@ -18,11 +18,15 @@ public class LaundryOptionRequest {
 
         private String description;
 
+        @NotNull(message = "옵션 활성 여부는 필수입니다.")
+        private Boolean isActive;
+
         public LaundryOption toEntity() {
             return LaundryOption.builder()
                     .name(name)
                     .extraPrice(extraPrice)
                     .description(description)
+                    .isActive(isActive)
                     .build();
         }
     }
@@ -37,5 +41,8 @@ public class LaundryOptionRequest {
         private Integer extraPrice;
 
         private String description;
+
+        @NotNull(message = "옵션 활성 여부는 필수입니다.")
+        private Boolean isActive;
     }
 }

--- a/clean4u/src/main/resources/db/data.sql
+++ b/clean4u/src/main/resources/db/data.sql
@@ -7,10 +7,12 @@ insert into laundry_item_tb(name, category, base_price, description, created_at)
                                                                                      ('드라이클리닝', 'SPECIAL', 20000, '드라이클리닝이 필요한 의류 전용 세탁입니다.', now()),
                                                                                      ('기타', 'ETC', 5000, '분류되지 않은 기타 세탁물 항목입니다.', now());
 
-insert into laundry_option_tb(name, extra_price) values
-                                                     ('표백', 2000),
-                                                     ('향 추가', 1000),
-                                                     ('프리미엄 세제', 6000);
+insert into laundry_option_tb(name, extra_price, description, is_active, created_at) values
+         ('표백', 2000, '표백 처리를 통해 얼룩과 변색을 개선합니다.', true, now()),
+         ('향 추가', 1000, '세탁 후 은은한 향을 추가해 드립니다.', true, now()),
+         ('프리미엄 세제', 6000, '프리미엄 세제를 사용해 섬유 손상을 줄입니다.', true, now()),
+         ('얼룩 집중 제거', 4000, '목, 소매 등 심한 얼룩을 집중적으로 제거합니다.', false, now()),
+         ('저자극 세탁', 3000, '피부 자극을 줄인 저자극 세탁 옵션입니다.', false, now());
 
 insert into supply_item_tb(name, unit, stock_quantity, safety_stock) values
                                                            ('세탁세제', 'ml', 5, 10),

--- a/clean4u/src/main/resources/static/base.css
+++ b/clean4u/src/main/resources/static/base.css
@@ -22,6 +22,9 @@
     --warning: #FFB74D;
     --success: #66BB6A;
 
+    --status-active: #22CC71;
+    --status-inactive: #95A5A6;
+
     --action-edit: #FFB74D;
     --action-edit-hover: #FFA726;
     --action-delete: #EF5350;

--- a/clean4u/src/main/resources/static/detail.css
+++ b/clean4u/src/main/resources/static/detail.css
@@ -97,3 +97,19 @@
     font-size: 1.5rem;
     font-weight: 800;
 }
+
+.status-active,
+.status-inactive {
+    padding: 0.3rem 0.75rem;
+    border-radius: 50px;
+    font-size: 0.9rem;
+    color: var(--color-white);
+}
+
+.status-active {
+    background: var(--status-active);
+}
+
+.status-inactive {
+    background: var(--status-inactive);
+}

--- a/clean4u/src/main/resources/templates/laundryOption/detail-form.mustache
+++ b/clean4u/src/main/resources/templates/laundryOption/detail-form.mustache
@@ -1,19 +1,68 @@
 {{> layout/header}}
 
-<div class="container p-5">
+{{> layout/background}}
 
-    <div class="d-flex justify-content-end">
-        <form action="/laundry-option/{{laundryOption.id}}/delete" method="post">
-            <button class="btn btn-danger">삭제</button>
-        </form>
-        <a href="/laundry-option/{{laundryOption.id}}/update" class="btn btn-warning me-1">수정</a>
-
-    </div>
-
-    <div>
-        <h2><b>{{laundryOption.name}}</b></h2>
-        <hr/>
-        <h4><b>{{laundryOption.extraPrice}}</b></h4>
+<!-- http://localhost:8080/laundry-option/1 -->
+<div class="detail-container">
+    <div class="detail-container-content">
+        <div class="buttons">
+            <form action="/laundry-option" method="get">
+                <button class="btn btn-back"><i class="fa-solid fa-arrow-left"></i>목록으로</button>
+            </form>
+            <div class="button-right">
+                <form action="/laundry-option/{{laundryOption.id}}/update" method="post">
+                    <button class="btn btn-edit"><i class="fa-solid fa-edit"></i> 수정</button>
+                </form>
+                <form action="/laundry-option/{{laundryOption.id}}/delete" method="post">
+                    <button class="btn btn-delete"><i class="fa-solid fa-trash"></i>삭제</button>
+                </form>
+            </div>
+        </div>
+        <div class="detail-card">
+            <div class="detail-header">
+                <i class="fa-solid fa-tag"></i>
+                <h4>{{laundryOption.name}}</h4>
+            </div>
+            <div class="detail-body">
+                <div class="detail-item">
+                    <span class="detail-label">
+                        <i class="fa-solid fa-won-sign"></i>
+                        기본 가격
+                    </span>
+                    <span class="detail-value price">
+                        {{laundryOption.extraPrice}}
+                    </span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">
+                        <i class="fa-solid fa-circle-info"></i>
+                        설명
+                    </span>
+                    <span class="detail-value">
+                        {{laundryOption.description}}
+                    </span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">
+                        <i class="fa-solid fa-heart"></i>
+                        활성 여부
+                    </span>
+                    <span class="detail-value {{#laundryOption.isActive}}status-active{{/laundryOption.isActive}} {{^laundryOption.isActive}}status-inactive{{/laundryOption.isActive}}">
+                        {{#laundryOption.isActive}}활성{{/laundryOption.isActive}}
+                        {{^laundryOption.isActive}}비활성{{/laundryOption.isActive}}
+                    </span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">
+                        <i class="fa-solid fa-hourglass"></i>
+                        생성일
+                    </span>
+                    <span class="detail-value">
+                        {{laundryOption.createdAt}}
+                    </span>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/clean4u/src/main/resources/templates/laundryOption/list-form.mustache
+++ b/clean4u/src/main/resources/templates/laundryOption/list-form.mustache
@@ -1,22 +1,39 @@
 {{> layout/header}}
 
-<div class="container p-5">
-    <h2 class="mb-4">세탁물 옵션
-    <a href="/laundry-option/save" class="btn btn-primary">생성</a>
-    </h2>
-    {{#laundryOptionList}}
-        <div class="card mb-3">
-            <div class="card-body">
-                <h4 class="card-title mb-3">{{name}}</h4>
-                <a href="/laundry-option/{{id}}" class="btn btn-primary">상세보기</a>
-            </div>
+{{> layout/background}}
+
+<!-- http://localhost:8080/laundry-option -->
+<div class="content-section">
+    <div class="container">
+        <div class="section-header">
+            <h2 class="section-title">
+                <i class="fa-solid fa-shirt"></i>세탁물 목록
+            </h2>
+            <a href="/laundry-option/save" class="btn btn-create">
+                <span>+</span>생성
+            </a>
         </div>
-    {{/laundryOptionList}}
-    {{^laundryOptionList}}
-        <div class="alert alert-info" role="alert">
-            등록된 세탁물 옵션이 없습니다.
+
+        <div class="card-list">
+            {{#laundryOptionList}}
+                <a href="/laundry-option/{{id}}" class="card">
+                    <div class="card-header">
+                        <i class="fa-solid fa-tag"></i>
+                        <h4>{{name}}</h4>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-info">
+                            <span class="info-label">추가요금:</span>
+                            <span class="info-value price">{{extraPrice}}</span>
+                        </div>
+                    </div>
+                </a>
+            {{/laundryOptionList}}
         </div>
-    {{/laundryOptionList}}
+        {{^laundryOptionList}}
+            <p class="blank">등록된 세탁물이 없습니다.</p>
+        {{/laundryOptionList}}
+    </div>
 </div>
 
 {{> layout/footer}}

--- a/clean4u/src/main/resources/templates/layout/header.mustache
+++ b/clean4u/src/main/resources/templates/layout/header.mustache
@@ -44,6 +44,11 @@
                             <i class="fa-solid fa-shirt"></i> 세탁관리
                         </a>
                     </li>
+                    <li class="nav-item active">
+                        <a class="nav-link" href="/laundry-option">
+                            <i class="fa-solid fa-tag"></i> 세탁 옵션 관리
+                        </a>
+                    </li>
                     <li class="nav-item">
                         <a class="nav-link" href="/supply-item">
                             <i class="fa-solid fa-box"></i> 세탁물품관리


### PR DESCRIPTION
## 변경 배경
LaundryOption의 상세 정보에 description, 활성여부, 생성/수정일 정보를 추가합니다.

## 주요 변경 사항
- LaundryOption BaseTimeEntity 적용(BE)
- LaundryOption 활성여부 필터 상태값 view로 전달(FE)
- LaundryOption 삭제 버튼 활성/비활성 상태 전환으로 변경(FE)
- LaundryOption 삭제 버튼 활성/비활성 상태 전환 처리(BE)

## 기술 스택 및 구현 방식
- BE, FE 작업
- Spring Boot, JPA, Mustache
- Entity 필드 추가 및 BaseTimeEntity 상속

## 영향 범위
- [x] Frontend
- [x] Backend
- [x] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 데이터베이스 마이그레이션 확인
- [x] 기존 기능 정상 동작 확인

### 테스트 방법
1. description 필드 추가 확인
2. 활성여부 필드 추가 확인
3. 생성/수정일 정보 확인
4. 관련 API 동작 확인

## 관련 이슈
- 이슈 번호: #95
- Closes #95