### PR TITLE
feat: JPA 상속 적용 및 Repository 구조 변경(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.clean4u._core.exception.Exception401;
+import org.example.clean4u._core.exception.Exception404;
 import org.example.clean4u.employee.Employee;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -38,7 +39,8 @@ public class LaundryItemController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        LaundryItem laundryItem = repository.findById(id);
+        LaundryItem laundryItem = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 세탁물을 찾을 수 없습니다."));
         model.addAttribute("laundryItem", laundryItem);
 
         return "laundryItem/detail-form";
@@ -73,7 +75,8 @@ public class LaundryItemController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        LaundryItem laundryItem = repository.findById(id);
+        LaundryItem laundryItem = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 세탁물을 찾을 수 없습니다."));
         model.addAttribute("laundryItem", laundryItem);
 
         LaundryCategory category = laundryItem.getCategory();
@@ -95,7 +98,9 @@ public class LaundryItemController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        repository.updateById(id, updateDTO);
+        LaundryItem laundryItem = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 세탁물을 찾을 수 없습니다."));
+        laundryItem.update(updateDTO);
         return "redirect:/laundry-item";
     }
 

--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemRepository.java
@@ -1,56 +1,14 @@
 package org.example.clean4u.laundryItem;
 
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
-import org.example.clean4u._core.exception.Exception404;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
-@Repository
-@RequiredArgsConstructor
-public class LaundryItemRepository {
+public interface LaundryItemRepository extends JpaRepository<LaundryItem, Long> {
+    List<LaundryItem> findByCategory(LaundryCategory category);
 
-    private final EntityManager em;
+    List<LaundryItem> findByNameContaining(String name);
 
-    @Transactional
-    public LaundryItem save(LaundryItem laundryItem) {
-        em.persist(laundryItem);
-        return laundryItem;
-    }
-
-    public List<LaundryItem> findAll() {
-        return em.createQuery(
-                        "SELECT li FROM LaundryItem li ORDER BY li.id DESC"
-                        , LaundryItem.class)
-                .getResultList();
-    }
-
-    public LaundryItem findById(Long id) {
-        LaundryItem laundryItem = em.find(LaundryItem.class, id);
-        if (laundryItem == null) {
-            throw new Exception404("해당 세탁물을 찾을 수 없습니다.");
-        }
-        return laundryItem;
-    }
-
-    @Transactional
-    public LaundryItem updateById(Long id, LaundryItemRequest.UpdateDTO reqDTO) {
-        LaundryItem laundryItem = em.find(LaundryItem.class, id);
-        if (laundryItem == null) {
-            throw new Exception404("해당 세탁물을 찾을 수 없습니다.");
-        }
-        laundryItem.update(reqDTO);
-        return laundryItem;
-    }
-
-    @Transactional
-    public void deleteById(Long id) {
-        LaundryItem laundryItem = em.find(LaundryItem.class, id);
-        if (laundryItem == null) {
-            throw new Exception404("해당 세탁물을 찾을 수 없습니다.");
-        }
-        em.remove(laundryItem);
-    }
+    Optional<LaundryItem> findByName(String name);
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionController.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.clean4u._core.exception.Exception401;
+import org.example.clean4u._core.exception.Exception404;
 import org.example.clean4u.employee.Employee;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -38,7 +39,8 @@ public class LaundryOptionController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        LaundryOption laundryOption = repository.findById(id);
+        LaundryOption laundryOption = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 옵션을 찾을 수 없습니다."));
         model.addAttribute("laundryOption", laundryOption);
 
         return "/laundryOption/detail-form";
@@ -73,7 +75,8 @@ public class LaundryOptionController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        LaundryOption laundryOption = repository.findById(id);
+        LaundryOption laundryOption = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 옵션을 찾을 수 없습니다."));
         model.addAttribute("laundryOption", laundryOption);
         return "laundryOption/update-form";
     }
@@ -85,7 +88,9 @@ public class LaundryOptionController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        repository.updateById(id, updateDTO);
+        LaundryOption laundryOption = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 옵션을 찾을 수 없습니다."));
+        laundryOption.update(updateDTO);
         return "redirect:/laundry-option/{id}";
     }
 

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRepository.java
@@ -1,56 +1,14 @@
 package org.example.clean4u.laundryOption;
 
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
-import org.example.clean4u._core.exception.Exception404;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
-@Repository
-@RequiredArgsConstructor
-public class LaundryOptionRepository {
+public interface LaundryOptionRepository extends JpaRepository<LaundryOption, Long> {
+    List<LaundryOption> findByIsActive(Boolean isActive);
 
-    private final EntityManager em;
+    List<LaundryOption> findByNameContaining(String name);
 
-    @Transactional
-    public LaundryOption save(LaundryOption laundryOption) {
-        em.persist(laundryOption);
-        return laundryOption;
-    }
-
-    public List<LaundryOption> findAll() {
-        return em.createQuery(
-                "SELECT lo FROM LaundryOption lo ORDER BY id DESC",
-                LaundryOption.class
-        ).getResultList();
-    }
-
-    public LaundryOption findById(Long id) {
-        LaundryOption laundryOption = em.find(LaundryOption.class, id);
-        if (laundryOption == null) {
-            throw new Exception404("해당 세탁물 옵션을 찾을 수 없습니다.");
-        }
-        return laundryOption;
-    }
-
-    @Transactional
-    public LaundryOption updateById(Long id, LaundryOptionRequest.UpdateDTO updateDTO) {
-        LaundryOption laundryOption = em.find(LaundryOption.class, id);
-        if (laundryOption == null) {
-            throw new Exception404("해당 세탁물 옵션을 찾을 수 없습니다.");
-        }
-        laundryOption.update(updateDTO);
-        return laundryOption;
-    }
-
-    @Transactional
-    public void deleteById(Long id) {
-        LaundryOption laundryOption = em.find(LaundryOption.class, id);
-        if (laundryOption == null) {
-            throw new Exception404("해당 세탁물 옵션을 찾을 수 없습니다.");
-        }
-        em.remove(laundryOption);
-    }
+    Optional<LaundryOption> findByName(String name);
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.clean4u._core.exception.Exception401;
+import org.example.clean4u._core.exception.Exception404;
 import org.example.clean4u.employee.Employee;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -38,7 +39,8 @@ public class SupplyItemController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        SupplyItem supplyItem = repository.findById(id);
+        SupplyItem supplyItem = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 자재를 찾을 수 없습니다."));
         model.addAttribute("supplyItem", supplyItem);
 
         return "supplyItem/detail-form";
@@ -73,7 +75,8 @@ public class SupplyItemController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        SupplyItem supplyItem = repository.findById(id);
+        SupplyItem supplyItem = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 자재를 찾을 수 없습니다."));
         model.addAttribute("supplyItem", supplyItem);
         return "supplyItem/update-form";
     }
@@ -85,7 +88,9 @@ public class SupplyItemController {
         if (sessionUser == null) {
             throw new Exception401("로그인이 필요합니다.");
         }
-        repository.updateById(id, updateDTO);
+        SupplyItem supplyItem = repository.findById(id)
+                .orElseThrow(() -> new Exception404("해당 자재를 찾을 수 없습니다."));
+        supplyItem.update(updateDTO);
         return "redirect:/supply-item/{id}";
     }
 

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRepository.java
@@ -1,56 +1,16 @@
 package org.example.clean4u.supplyItem;
 
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
-import org.example.clean4u._core.exception.Exception404;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
-@Repository
-@RequiredArgsConstructor
-public class SupplyItemRepository {
+public interface SupplyItemRepository extends JpaRepository<SupplyItem, Long> {
+    @Query("SELECT si FROM SupplyItem si WHERE si.stockQuantity <= si.safetyStock")
+    List<SupplyItem> findLowStockItems();
 
-    private final EntityManager em;
+    List<SupplyItem> findByNameContaining(String name);
 
-    @Transactional
-    public SupplyItem save(SupplyItem supplyItem) {
-        em.persist(supplyItem);
-        return supplyItem;
-    }
-
-    public List<SupplyItem> findAll() {
-        return em.createQuery(
-                "SELECT si FROM SupplyItem si ORDER BY si.id DESC",
-                SupplyItem.class
-        ).getResultList();
-    }
-
-    public SupplyItem findById(Long id) {
-        SupplyItem supplyItem = em.find(SupplyItem.class, id);
-        if (supplyItem == null) {
-            throw new Exception404("해당 자재를 찾을 수 없습니다.");
-        }
-        return supplyItem;
-    }
-
-    @Transactional
-    public SupplyItem updateById(Long id, SupplyItemRequest.UpdateDTO updateDTO) {
-        SupplyItem supplyItem = em.find(SupplyItem.class, id);
-        if (supplyItem == null) {
-            throw new Exception404("해당 자재를 찾을 수 없습니다.");
-        }
-        supplyItem.update(updateDTO);
-        return supplyItem;
-    }
-
-    @Transactional
-    public void deleteById(Long id) {
-        SupplyItem supplyItem = em.find(SupplyItem.class, id);
-        if (supplyItem == null) {
-            throw new Exception404("해당 자재를 찾을 수 없습니다.");
-        }
-        em.remove(supplyItem);
-    }
+    Optional<SupplyItem> findByName(String name);
 }


### PR DESCRIPTION
## 변경 배경
Repository를 JPA 상속 형태로 변경하여 구조를 개선합니다.

## 주요 변경 사항
- LaundryItem 리포지토리 JPA 상속 형태로 변경(BE)
- LaundryOption 리포지토리 JPA 상속 형태로 변경(BE)
- SupplyItem 리포지토리 JPA 상속 형태로 변경(BE)

## 기술 스택 및 구현 방식
- BE 작업
- Spring Boot, Spring Data JPA
- JpaRepository 인터페이스 상속 구조 적용

## 영향 범위
- [ ] Frontend
- [x] Backend
- [ ] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

### 테스트 방법
1. 각 Repository의 상속 구조 확인
2. 기본 CRUD 메서드 동작 확인
3. 커스텀 쿼리 메서드 동작 확인

## 관련 이슈
- 이슈 번호: #138
- Closes #138