### PR TITLE
feat: LaundryOption 삭제 버튼 활성/비활성 상태 전환으로 변경(FE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionController.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionController.java
@@ -81,9 +81,16 @@ public class LaundryOptionController {
     }
 
     // http://localhost:8080/laundry-option/{laundryOptionId}/delete
-    @PostMapping("/laundry-option/{laundryOptionId}/delete")
-    public String delete(@PathVariable Long laundryOptionId) {
-        service.delete(laundryOptionId);
-        return "redirect:/laundry-option";
+    @PostMapping("/laundry-option/{laundryOptionId}/deactivate")
+    public String deactivate(@PathVariable Long laundryOptionId) {
+        service.deactivate(laundryOptionId);
+        return "redirect:/laundry-option/" + laundryOptionId;
+    }
+
+    // http://localhost:8080/laundry-option/{laundryOptionId}/delete
+    @PostMapping("/laundry-option/{laundryOptionId}/activate")
+    public String activate(@PathVariable Long laundryOptionId) {
+        service.activate(laundryOptionId);
+        return "redirect:/laundry-option/" + laundryOptionId;
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionService.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionService.java
@@ -58,10 +58,17 @@ public class LaundryOptionService {
     }
 
     @Transactional
-    public void delete(Long laundryOptionId) {
-        repository.findById(laundryOptionId)
+    public void deactivate(Long laundryOptionId) {
+        LaundryOption laundryOption = repository.findById(laundryOptionId)
                 .orElseThrow(() -> new Exception404("해당 세탁물 옵션을 찾을 수 없습니다."));
-        repository.deleteById(laundryOptionId);
+        laundryOption.updateIsActive(false);
+    }
+
+    @Transactional
+    public void activate(Long laundryOptionId) {
+        LaundryOption laundryOption = repository.findById(laundryOptionId)
+                .orElseThrow(() -> new Exception404("해당 세탁물 옵션을 찾을 수 없습니다."));
+        laundryOption.updateIsActive(true);
     }
 
     public List<LaundryOptionResponse.ListDTO> findByIsActive(Boolean isActive) {

--- a/clean4u/src/main/resources/static/base.css
+++ b/clean4u/src/main/resources/static/base.css
@@ -29,6 +29,8 @@
     --action-edit-hover: #FFA726;
     --action-delete: #EF5350;
     --action-delete-hover: #E53935;
+    --action-active: #66BB6A;
+    --action-active-hover: #4CAF50;
 
     --badge-warning: #FF0000;
     --badge-safe: #33FF33;

--- a/clean4u/src/main/resources/static/components.css
+++ b/clean4u/src/main/resources/static/components.css
@@ -78,12 +78,21 @@
     background: var(--action-delete);
 }
 
+.btn-activate {
+    padding: 0.5rem 1rem;
+    background: var(--action-active);
+}
+
 .btn-edit:hover {
     background: var(--action-edit-hover);
 }
 
 .btn-delete:hover {
     background: var(--action-delete-hover);
+}
+
+.btn-activate:hover {
+    background: var(--action-active-hover);
 }
 
 .btn-back {

--- a/clean4u/src/main/resources/templates/laundryOption/detail-form.mustache
+++ b/clean4u/src/main/resources/templates/laundryOption/detail-form.mustache
@@ -13,9 +13,16 @@
                 <a href="/laundry-option/{{laundryOption.id}}/update" class="btn btn-edit">
                     <i class="fa-solid fa-edit"></i> 수정
                 </a>
-                <form action="/laundry-option/{{laundryOption.id}}/delete" method="post">
-                    <button class="btn btn-delete"><i class="fa-solid fa-trash"></i>삭제</button>
+                {{#laundryOption.isActive}}
+                <form action="/laundry-option/{{laundryOption.id}}/deactivate" method="post">
+                    <button class="btn btn-delete"><i class="fa-solid fa-ban"></i>비활성화</button>
                 </form>
+                {{/laundryOption.isActive}}
+                {{^laundryOption.isActive}}
+                <form action="/laundry-option/{{laundryOption.id}}/activate" method="post">
+                    <button class="btn btn-activate"><i class="fa-solid fa-check"></i>활성화</button>
+                </form>
+                {{/laundryOption.isActive}}
             </div>
         </div>
         <div class="detail-card">


### PR DESCRIPTION
## 변경 배경
LaundryOption의 삭제 기능을 비활성화로 수정합니다.

## 주요 변경 사항
- LaundryOption 삭제 버튼 활성/비활성 상태 전환으로 변경(FE)
- LaundryOption 삭제 버튼 활성/비활성 상태 전환 처리(BE)

## 기술 스택 및 구현 방식
- FE, BE 작업
- Mustache, CSS, JavaScript, Spring Boot
- 삭제 기능 비활성화 처리

## 영향 범위
- [x] Frontend
- [x] Backend
- [ ] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 삭제 버튼 상태 확인

### 테스트 방법
1. 삭제 버튼 비활성화 확인
2. 삭제 기능 동작 확인
3. 상태 전환 동작 확인

## 관련 이슈
- 이슈 번호: #197
- Closes #197