### PR TITLE
feat: SupplyItem 삭제 기능 비활성화로 수정(FE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItem.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItem.java
@@ -28,13 +28,17 @@ public class SupplyItem extends BaseTimeEntity {
     @Column(name = "safety_stock", nullable = false)
     private Integer safetyStock;
 
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
     @Builder
-    public SupplyItem(Long id, String name, String unit, Integer stockQuantity, Integer safetyStock) {
+    public SupplyItem(Long id, String name, String unit, Integer stockQuantity, Integer safetyStock, Boolean isActive) {
         this.id = id;
         this.name = name;
         this.unit = unit;
         this.stockQuantity = stockQuantity;
         this.safetyStock = safetyStock;
+        this.isActive = isActive != null ? isActive : true;
     }
 
     public void update(SupplyItemRequest.UpdateDTO updateDTO) {
@@ -42,6 +46,7 @@ public class SupplyItem extends BaseTimeEntity {
         this.unit = updateDTO.getUnit();
         this.stockQuantity = updateDTO.getStockQuantity();
         this.safetyStock = updateDTO.getSafetyStock();
+        this.isActive = updateDTO.getIsActive();
     }
 
     public void updateName(String newName) {
@@ -70,5 +75,9 @@ public class SupplyItem extends BaseTimeEntity {
             throw new IllegalArgumentException("안전 재고는 0 이상 이어야 합니다.");
         }
         this.safetyStock = newSafetyStock;
+    }
+
+    public void updateIsActive(Boolean newIsActive) {
+        this.isActive = newIsActive;
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
@@ -80,9 +80,16 @@ public class SupplyItemController {
     }
 
     // http://localhost:8080/supply-item/{supplyItemId}/delete
-    @PostMapping("/supply-item/{supplyItemId}/delete")
-    public String delete(@PathVariable Long supplyItemId) {
-        service.delete(supplyItemId);
-        return "redirect:/supply-item";
+    @PostMapping("/supply-item/{supplyItemId}/deactivate")
+    public String deactivate(@PathVariable Long supplyItemId) {
+        service.deactivate(supplyItemId);
+        return "redirect:/supply-item/" + supplyItemId;
+    }
+
+    // http://localhost:8080/supply-item/{supplyItemId}/delete
+    @PostMapping("/supply-item/{supplyItemId}/activate")
+    public String activate(@PathVariable Long supplyItemId) {
+        service.activate(supplyItemId);
+        return "redirect:/supply-item/" + supplyItemId;
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRequest.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRequest.java
@@ -23,12 +23,16 @@ public class SupplyItemRequest {
         @Min(value = 0, message = "안전 재고는 0 이상 이어야 합니다.")
         private Integer safetyStock;
 
+        @NotNull(message = "재고 활성 여부는 필수입니다.")
+        private Boolean isActive;
+
         public SupplyItem toEntity() {
             return SupplyItem.builder()
                     .name(name)
                     .unit(unit)
                     .stockQuantity(stockQuantity)
                     .safetyStock(safetyStock)
+                    .isActive(isActive)
                     .build();
         }
     }
@@ -48,5 +52,8 @@ public class SupplyItemRequest {
         @NotNull(message = "안전 재고는 필수입니다.")
         @Min(value = 0, message = "안전 재고는 0 이상 이어야 합니다.")
         private Integer safetyStock;
+
+        @NotNull(message = "재고 활성 여부는 필수입니다.")
+        private Boolean isActive;
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemResponse.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemResponse.java
@@ -12,6 +12,7 @@ public class SupplyItemResponse {
         private Integer stockQuantity;
         private Integer safetyStock;
         private Boolean isLowStock;
+        private Boolean isActive;
 
         public ListDTO(SupplyItem supplyItem) {
             this.id = supplyItem.getId();
@@ -20,6 +21,7 @@ public class SupplyItemResponse {
             this.stockQuantity = supplyItem.getStockQuantity();
             this.safetyStock = supplyItem.getSafetyStock();
             this.isLowStock = supplyItem.getStockQuantity() <= supplyItem.getSafetyStock();
+            this.isActive = supplyItem.getIsActive();
         }
     }
 
@@ -31,6 +33,7 @@ public class SupplyItemResponse {
         private Integer stockQuantity;
         private Integer safetyStock;
         private Boolean isLowStock;
+        private Boolean isActive;
         private String createdAt;
         private String updatedAt;
 
@@ -41,6 +44,7 @@ public class SupplyItemResponse {
             this.stockQuantity = supplyItem.getStockQuantity();
             this.safetyStock = supplyItem.getSafetyStock();
             this.isLowStock = supplyItem.getStockQuantity() <= supplyItem.getSafetyStock();
+            this.isActive = supplyItem.getIsActive();
             this.createdAt = DateUtil.timestampFormat(supplyItem.getCreatedAt());
             this.updatedAt = DateUtil.timestampFormat(supplyItem.getUpdatedAt());
         }
@@ -53,6 +57,7 @@ public class SupplyItemResponse {
         private String unit;
         private Integer stockQuantity;
         private Integer safetyStock;
+        private Boolean isActive;
 
         public UpdateFormDTO(SupplyItem supplyItem) {
             this.id = supplyItem.getId();
@@ -60,6 +65,7 @@ public class SupplyItemResponse {
             this.unit = supplyItem.getUnit();
             this.stockQuantity = supplyItem.getStockQuantity();
             this.safetyStock = supplyItem.getSafetyStock();
+            this.isActive = supplyItem.getIsActive();
         }
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemService.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemService.java
@@ -59,10 +59,17 @@ public class SupplyItemService {
     }
 
     @Transactional
-    public void delete(Long supplyItemId) {
-        repository.findById(supplyItemId)
+    public void deactivate(Long supplyItemId) {
+        SupplyItem supplyItem = repository.findById(supplyItemId)
                 .orElseThrow(() -> new Exception404("해당 자재를 찾을 수 없습니다."));
-        repository.deleteById(supplyItemId);
+        supplyItem.updateIsActive(false);
+    }
+
+    @Transactional
+    public void activate(Long supplyItemId) {
+        SupplyItem supplyItem = repository.findById(supplyItemId)
+                .orElseThrow(() -> new Exception404("해당 자재를 찾을 수 없습니다."));
+        supplyItem.updateIsActive(true);
     }
 
     public List<SupplyItemResponse.ListDTO> findByNameContaining(String name) {

--- a/clean4u/src/main/resources/db/data.sql
+++ b/clean4u/src/main/resources/db/data.sql
@@ -1,11 +1,11 @@
 insert into laundry_item_tb(name, category, base_price, description, created_at) values
-                                                                                     ('셔츠', 'TOP', 3000, '일상적으로 착용하는 일반 셔츠 세탁입니다.', now()),
-                                                                                     ('바지', 'BOTTOM', 4000, '면바지, 슬랙스 등 일반 바지 세탁입니다.', now()),
-                                                                                     ('코트', 'OUTER', 8000, '겨울용 코트 및 두꺼운 아우터 세탁입니다.', now()),
-                                                                                     ('이불', 'BEDDING', 12000, '이불, 담요 등 침구류 세탁 서비스입니다.', now()),
-                                                                                     ('모자', 'ACCESSORY', 2000, '캡모자, 비니 등 모자류 세탁입니다.', now()),
-                                                                                     ('드라이클리닝', 'SPECIAL', 20000, '드라이클리닝이 필요한 의류 전용 세탁입니다.', now()),
-                                                                                     ('기타', 'ETC', 5000, '분류되지 않은 기타 세탁물 항목입니다.', now());
+     ('셔츠', 'TOP', 3000, '일상적으로 착용하는 일반 셔츠 세탁입니다.', now()),
+     ('바지', 'BOTTOM', 4000, '면바지, 슬랙스 등 일반 바지 세탁입니다.', now()),
+     ('코트', 'OUTER', 8000, '겨울용 코트 및 두꺼운 아우터 세탁입니다.', now()),
+     ('이불', 'BEDDING', 12000, '이불, 담요 등 침구류 세탁 서비스입니다.', now()),
+     ('모자', 'ACCESSORY', 2000, '캡모자, 비니 등 모자류 세탁입니다.', now()),
+     ('드라이클리닝', 'SPECIAL', 20000, '드라이클리닝이 필요한 의류 전용 세탁입니다.', now()),
+     ('기타', 'ETC', 5000, '분류되지 않은 기타 세탁물 항목입니다.', now());
 
 insert into laundry_option_tb(name, extra_price, description, is_active, created_at) values
          ('표백', 2000, '표백 처리를 통해 얼룩과 변색을 개선합니다.', true, now()),
@@ -14,14 +14,14 @@ insert into laundry_option_tb(name, extra_price, description, is_active, created
          ('얼룩 집중 제거', 4000, '목, 소매 등 심한 얼룩을 집중적으로 제거합니다.', false, now()),
          ('저자극 세탁', 3000, '피부 자극을 줄인 저자극 세탁 옵션입니다.', false, now());
 
-insert into supply_item_tb(name, unit, stock_quantity, safety_stock) values
-                                                           ('세탁세제', 'ml', 5, 10),
-                                                           ('섬유유연제', 'ml', 30, 10),
-                                                           ('표백제', 'ml', 5, 3),
-                                                           ('비닐포장지', 'ea', 100, 100),
-                                                           ('종이포장봉투', 'ea', 500, 100),
-                                                           ('옷걸이', 'ea', 300, 100),
-                                                           ('세탁망', 'ea', 150, 100);
+insert into supply_item_tb(name, unit, stock_quantity, safety_stock, is_active, created_at) values
+                           ('세탁세제', '병', 5, 10, true, now()),
+                           ('섬유유연제', '병', 30, 10, false, now()),
+                           ('표백제', '병', 5, 3, false, now()),
+                           ('비닐포장지', '개', 100, 100, true, now()),
+                           ('종이포장봉투', '개', 500, 100, true, now()),
+                           ('옷걸이', '개', 300, 100, false, now()),
+                           ('세탁망', '개', 150, 100, true, now());
 
 INSERT INTO employee_tb
 (name, username, password, email, user_role, user_status)

--- a/clean4u/src/main/resources/static/base.css
+++ b/clean4u/src/main/resources/static/base.css
@@ -106,3 +106,14 @@ ul, ol {
     outline: 2px solid var(--color-light-blue);
     outline-offset: 2px;
 }
+
+input::placeholder,
+textarea::placeholder {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.update-header input::placeholder {
+    font-weight: inherit;
+    font-size: inherit;
+}

--- a/clean4u/src/main/resources/static/detail.css
+++ b/clean4u/src/main/resources/static/detail.css
@@ -11,6 +11,7 @@
     display: flex;
     flex-direction: column;
     width: 60%;
+    min-width: 700px;
 }
 
 .buttons {
@@ -127,5 +128,6 @@
 @media (max-width: 1024px) {
     .detail-container-content {
         width: 70%;
+        min-width: 0;
     }
 }

--- a/clean4u/src/main/resources/static/list.css
+++ b/clean4u/src/main/resources/static/list.css
@@ -82,7 +82,7 @@
 .card-info {
     display: flex;
     justify-content: space-between;
-    align-content: center;
+    align-items: center;
     padding: 0.75rem 0;
     border-bottom: 1px dashed var(--color-light-gray);
 }

--- a/clean4u/src/main/resources/static/supplyItem.css
+++ b/clean4u/src/main/resources/static/supplyItem.css
@@ -24,16 +24,18 @@
 }
 
 .supply-item .update-item{
-    gap: 7rem;
+    gap: 0.5rem;
 }
 
 .supply-item {
     width: 45%;
+    min-width: 600px;
 }
 
 @media (max-width: 1024px) {
     .supply-item {
-        width: 50%;
+        width: 70%;
+        min-width: 0;
     }
 }
 

--- a/clean4u/src/main/resources/static/update.css
+++ b/clean4u/src/main/resources/static/update.css
@@ -11,6 +11,7 @@
     display: flex;
     flex-direction: column;
     width: 60%;
+    min-width: 700px;
 }
 
 .update-card {
@@ -39,7 +40,6 @@
 }
 
 .update-header input {
-    margin: 0 auto;
     font-size: 1.5rem;
     font-weight: 700;
     text-align: center;
@@ -65,7 +65,7 @@
     padding: 1.5rem 0;
     border-bottom: 1px dashed var(--color-light-gray);
     align-items: center;
-    gap: 5rem;
+    gap: 1.5rem;
 }
 
 .update-item:last-child {
@@ -77,7 +77,7 @@
     font-weight: 600;
     display: flex;
     align-items: center;
-    min-width: 100px;
+    min-width: 150px;
 }
 
 .update-label i {
@@ -139,6 +139,7 @@
 
     .update-container-content {
         width: 70%;
+        min-width: 0;
     }
 }
 

--- a/clean4u/src/main/resources/templates/supplyItem/detail-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItem/detail-form.mustache
@@ -13,9 +13,16 @@
                 <a href="/supply-item/{{supplyItem.id}}/update" class="btn btn-edit">
                     <i class="fa-solid fa-edit"></i> 수정
                 </a>
-                <form action="/supply-item/{{supplyItem.id}}/delete" method="post">
-                    <button class="btn btn-delete"><i class="fa-solid fa-trash"></i>삭제</button>
-                </form>
+                {{#supplyItem.isActive}}
+                    <form action="/supply-item/{{supplyItem.id}}/deactivate" method="post">
+                        <button class="btn btn-delete"><i class="fa-solid fa-ban"></i>비활성화</button>
+                    </form>
+                {{/supplyItem.isActive}}
+                {{^supplyItem.isActive}}
+                    <form action="/supply-item/{{supplyItem.id}}/activate" method="post">
+                        <button class="btn btn-activate"><i class="fa-solid fa-check"></i>활성화</button>
+                    </form>
+                {{/supplyItem.isActive}}
             </div>
         </div>
         <div class="detail-card">
@@ -53,13 +60,33 @@
                 </div>
                 <div class="detail-item">
                     <span class="detail-label">
-                        {{#supplyItem.isLowStock}}<i class="fa-solid fa-triangle-exclamation"></i>{{/supplyItem.isLowStock}}
+                        {{#supplyItem.isLowStock}}
+                            <i class="fa-solid fa-triangle-exclamation"></i>{{/supplyItem.isLowStock}}
                         {{^supplyItem.isLowStock}}<i class="fa-solid fa-circle-check"></i>{{/supplyItem.isLowStock}}
                         재고 상태
                     </span>
                     <span class="detail-value stock-badge {{#supplyItem.isLowStock}}badge-warn{{/supplyItem.isLowStock}} {{^supplyItem.isLowStock}}badge-safe{{/supplyItem.isLowStock}}">
                         {{#supplyItem.isLowStock}}주의{{/supplyItem.isLowStock}}
                         {{^supplyItem.isLowStock}}안전{{/supplyItem.isLowStock}}
+                    </span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">
+                        <i class="fa-solid fa-heart"></i>
+                        활성 여부
+                    </span>
+                    <span class="detail-value {{#supplyItem.isActive}}status-active{{/supplyItem.isActive}} {{^supplyItem.isActive}}status-inactive{{/supplyItem.isActive}}">
+                        {{#supplyItem.isActive}}활성{{/supplyItem.isActive}}
+                        {{^supplyItem.isActive}}비활성{{/supplyItem.isActive}}
+                    </span>
+                </div>
+                <div class="detail-item">
+                    <span class="detail-label">
+                        <i class="fa-solid fa-hourglass"></i>
+                        생성일
+                    </span>
+                    <span class="detail-value">
+                        {{supplyItem.createdAt}}
                     </span>
                 </div>
             </div>

--- a/clean4u/src/main/resources/templates/supplyItem/list-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItem/list-form.mustache
@@ -57,6 +57,13 @@
                             <span class="info-label">단위:</span>
                             <span class="info-value">{{unit}}</span>
                         </div>
+                        <div class="card-info">
+                            <span class="info-label">재고 상태:</span>
+                            <span class="info-value stock-badge {{#isLowStock}}badge-warn{{/isLowStock}} {{^isLowStock}}badge-safe{{/isLowStock}}">
+                                {{#isLowStock}}주의{{/isLowStock}}
+                                {{^isLowStock}}안전{{/isLowStock}}
+                           </span>
+                        </div>
                     </div>
                 </a>
             {{/supplyItemList}}

--- a/clean4u/src/main/resources/templates/supplyItem/save-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItem/save-form.mustache
@@ -36,6 +36,16 @@
                         <input type="number" id="safetyStock" name="safetyStock" min="0" step="1"
                                placeholder="안전 재고 수량을 입력해주세요." class="update-value price">
                     </div>
+                    <div class="update-item">
+                        <label class="update-label">
+                            <i class="fa-solid fa-heart"></i>
+                            활성 여부
+                        </label>
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="isActive" name="isActive" value="true" checked>
+                            <span class="slider"></span>
+                        </label>
+                    </div>
                 </div>
                 <div class="bottom-buttons">
                     <a href="/supply-item" class="btn btn-back">취소</a>

--- a/clean4u/src/main/resources/templates/supplyItem/update-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItem/update-form.mustache
@@ -40,6 +40,18 @@
                                placeholder="안전 재고 수량을 입력해주세요." class="update-value price"
                                value="{{supplyItem.safetyStock}}">
                     </div>
+                    <div class="update-item">
+                        <label class="update-label">
+                            <i class="fa-solid fa-heart"></i>
+                            활성 여부
+                        </label>
+                        <input type="hidden" name="isActive" value="false">
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="isActive" name="isActive" value="true"
+                                   {{#supplyItem.isActive}}checked{{/supplyItem.isActive}}>
+                            <span class="slider"></span>
+                        </label>
+                    </div>
                 </div>
                 <div class="bottom-buttons">
                     <a href="/supply-item/{{supplyItem.id}}" class="btn btn-back">취소</a>


### PR DESCRIPTION
## 변경 배경
SupplyItem의 삭제 기능을 비활성화로 수정합니다.

## 주요 변경 사항
- SupplyItem 삭제 기능 비활성화로 수정(FE)

## 기술 스택 및 구현 방식
- FE 작업
- Mustache, CSS, JavaScript
- 삭제 기능 비활성화 처리

## 영향 범위
- [x] Frontend
- [ ] Backend
- [ ] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 삭제 버튼 상태 확인

### 테스트 방법
1. 삭제 버튼 비활성화 확인
2. 삭제 기능 동작 확인

## 관련 이슈
- 이슈 번호: #216
- Closes #216