### PR TITLE
feat: SupplyItem 필터링 조건 확장(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/_core/config/WebMvcConfig.java
+++ b/clean4u/src/main/java/org/example/clean4u/_core/config/WebMvcConfig.java
@@ -16,6 +16,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+
+        registry.addInterceptor(sessionInterceptor)
+                .addPathPatterns("/**");
+
+
         registry.addInterceptor(accessInterceptor)
                 .addPathPatterns(
                         "/employee/**",
@@ -37,8 +42,5 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         "/favicon.ico",
                         "/h2-console/**"
                 );
-
-        registry.addInterceptor(sessionInterceptor)
-                .addPathPatterns("/**");
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
@@ -25,12 +25,18 @@ public class SupplyItemController {
             @RequestParam(required = false) Boolean lowStock
     ) {
         List<SupplyItemResponse.ListDTO> supplyItemList;
-        if (lowStock != null && lowStock) {
-            supplyItemList = service.findLowStockItems();
-        } else if (lowStock != null) {
-            supplyItemList = service.findSafetyStockItems();
-        } else if (name != null && !name.isBlank()) {
+        boolean hasName = name != null && !name.isBlank();
+
+        if (hasName && lowStock != null && lowStock) {
+            supplyItemList = service.findByNameContainingAndLowStock(name);
+        } else if (hasName && lowStock != null && !lowStock) {
+            supplyItemList = service.findByNameContainingAndSafetyStock(name);
+        } else if (hasName) {
             supplyItemList = service.findByNameContaining(name);
+        } else if (lowStock != null && lowStock) {
+            supplyItemList = service.findLowStockItems();
+        } else if (lowStock != null && !lowStock) {
+            supplyItemList = service.findSafetyStockItems();
         } else {
             supplyItemList = service.getAllSupplyItems();
         }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRepository.java
@@ -2,6 +2,7 @@ package org.example.clean4u.supplyItem;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,13 +11,19 @@ public interface SupplyItemRepository extends JpaRepository<SupplyItem, Long> {
     @Query("SELECT si FROM SupplyItem si ORDER BY si.createdAt DESC")
     List<SupplyItem> findAllOrderByCreatedAtDesc();
 
-    @Query("SELECT si FROM SupplyItem si WHERE si.stockQuantity <= si.safetyStock")
+    @Query("SELECT si FROM SupplyItem si WHERE si.stockQuantity <= si.safetyStock ORDER BY si.createdAt DESC")
     List<SupplyItem> findLowStockItems();
 
-    @Query("SELECT si FROM SupplyItem si WHERE si.stockQuantity > si.safetyStock")
+    @Query("SELECT si FROM SupplyItem si WHERE si.stockQuantity > si.safetyStock ORDER BY si.createdAt DESC")
     List<SupplyItem> findSafetyStockItems();
 
     List<SupplyItem> findByNameContaining(String name);
+
+    @Query("SELECT si FROM SupplyItem si WHERE si.name LIKE CONCAT('%', :name, '%') AND si.stockQuantity <= si.safetyStock ORDER BY si.createdAt DESC")
+    List<SupplyItem> findByNameContainingAndLowStock(@Param("name") String name);
+
+    @Query("SELECT si FROM SupplyItem si WHERE si.name LIKE CONCAT('%', :name, '%') AND si.stockQuantity > si.safetyStock ORDER BY si.createdAt DESC")
+    List<SupplyItem> findByNameContainingAndSafetyStock(@Param("name") String name);
 
     Optional<SupplyItem> findByName(String name);
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemService.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemService.java
@@ -92,4 +92,18 @@ public class SupplyItemService {
                 .map(SupplyItemResponse.ListDTO::new)
                 .collect(Collectors.toList());
     }
+
+    public List<SupplyItemResponse.ListDTO> findByNameContainingAndLowStock(String name) {
+        List<SupplyItem> supplyItemList = repository.findByNameContainingAndLowStock(name);
+        return supplyItemList.stream()
+                .map(SupplyItemResponse.ListDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    public List<SupplyItemResponse.ListDTO> findByNameContainingAndSafetyStock(String name) {
+        List<SupplyItem> supplyItemList = repository.findByNameContainingAndSafetyStock(name);
+        return supplyItemList.stream()
+                .map(SupplyItemResponse.ListDTO::new)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 변경 배경
SupplyItem의 필터링 조건을 확장합니다.

## 주요 변경 사항
- SupplyItem 필터링 조건 확장(BE)

## 기술 스택 및 구현 방식
- BE 작업
- Spring Boot, Spring Data JPA
- Repository 쿼리 메서드 확장

## 영향 범위
- [ ] Frontend
- [x] Backend
- [x] Database
- [x] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 필터링 기능 정상 동작 확인

### 테스트 방법
1. 확장된 필터링 조건 확인
2. 필터링 동작 확인
3. 쿼리 성능 확인

## 관련 이슈
- 이슈 번호: #245
- Closes #245