### PR TITLE
feat: LaundryItem 필터링 조건 확장(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemController.java
@@ -25,10 +25,13 @@ public class LaundryItemController {
             @RequestParam(required = false) String name
     ) {
         List<LaundryItemResponse.ListDTO> laundryItemList;
+        boolean hasName = name != null && !name.isBlank();
 
-        if (category != null) {
+        if (category != null && hasName) {
+            laundryItemList = service.findByNameContainingAndCategory(category, name);
+        } else if (category != null) {
             laundryItemList = service.findByCategory(category);
-        } else if (name != null && !name.isBlank()) {
+        } else if (hasName) {
             laundryItemList = service.findByNameContaining(name);
         } else {
             laundryItemList = service.getAllLaundryItems();

--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemRepository.java
@@ -2,6 +2,7 @@ package org.example.clean4u.laundryItem;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +14,9 @@ public interface LaundryItemRepository extends JpaRepository<LaundryItem, Long> 
     List<LaundryItem> findByCategory(LaundryCategory category);
 
     List<LaundryItem> findByNameContaining(String name);
+
+    @Query("SELECT li FROM LaundryItem li WHERE li.name LIKE CONCAT('%', :name, '%') AND li.category = :category ORDER BY li.createdAt DESC")
+    List<LaundryItem> findByNameContainingAndCategory(@Param("category") LaundryCategory category, @Param("name") String name);
 
     Optional<LaundryItem> findByName(String name);
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemService.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemService.java
@@ -77,4 +77,11 @@ public class LaundryItemService {
                 .map(LaundryItemResponse.ListDTO::new)
                 .collect(Collectors.toList());
     }
+
+    public List<LaundryItemResponse.ListDTO> findByNameContainingAndCategory(LaundryCategory category, String name) {
+        List<LaundryItem> laundryItemList = repository.findByNameContainingAndCategory(category, name);
+        return laundryItemList.stream()
+                .map(LaundryItemResponse.ListDTO::new)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 변경 배경
LaundryItem의 필터링 조건을 확장합니다.

## 주요 변경 사항
- LaundryItem 필터링 조건 확장(BE)

## 기술 스택 및 구현 방식
- BE 작업
- Spring Boot, Spring Data JPA
- Repository 쿼리 메서드 확장

## 영향 범위
- [ ] Frontend
- [x] Backend
- [x] Database
- [x] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 필터링 기능 정상 동작 확인

### 테스트 방법
1. 확장된 필터링 조건 확인
2. 필터링 동작 확인
3. 쿼리 성능 확인

## 관련 이슈
- 이슈 번호: #251
- Closes #251