### PR TITLE
feat: 각 도메인 리스트 페이지에 페이징 적용(FE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemController.java
@@ -1,7 +1,10 @@
 package org.example.clean4u.laundryItem;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.clean4u._core.response.PageResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,37 +12,42 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @Controller
 public class LaundryItemController {
 
     private final LaundryItemService service;
 
-    // http://localhost:8080/laundry-item
-    @GetMapping("/laundry-item")
+    // http://localhost:8080/laundry-item/list
+    @GetMapping("/laundry-item/list")
     public String laundryItemList(
             Model model,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "9") int size,
             @RequestParam(required = false) LaundryCategory category,
-            @RequestParam(required = false) String name
+            @RequestParam(required = false) String name,
+            HttpSession session,
+            HttpServletRequest request
     ) {
-        List<LaundryItemResponse.ListDTO> laundryItemList;
-        boolean hasName = name != null && !name.isBlank();
+        int pageIndex = Math.max(0, page - 1);
 
-        if (category != null && hasName) {
-            laundryItemList = service.findByNameContainingAndCategory(category, name);
-        } else if (category != null) {
-            laundryItemList = service.findByCategory(category);
-        } else if (hasName) {
-            laundryItemList = service.findByNameContaining(name);
-        } else {
-            laundryItemList = service.getAllLaundryItems();
+        String queryString = request.getQueryString();
+
+        if (queryString != null) {
+            queryString = queryString.replaceAll("(&page=\\d+)", "");
+            queryString = queryString.replaceAll("(&size=\\d+)", "");
+            if (!queryString.isBlank()) {
+                queryString = "&" + queryString;
+            }
         }
 
-        model.addAttribute("laundryItemList", laundryItemList);
+        PageResponse<LaundryItemResponse.ListDTO> laundryItemListPage = service.laundryItemList(pageIndex, size, category, name);
+        model.addAttribute("laundryItemList", laundryItemListPage.getContent());
+        model.addAttribute("laundryItemPage", laundryItemListPage);
         model.addAttribute("name", name == null ? "" : name);
         model.addAttribute("category", category);
+        model.addAttribute("queryString", queryString);
+
         return "laundryItem/list-form";
     }
 
@@ -62,7 +70,7 @@ public class LaundryItemController {
     @PostMapping("/laundry-item/save")
     public String saveProc(@Valid LaundryItemRequest.SaveDTO saveDTO) {
         service.save(saveDTO);
-        return "redirect:/laundry-item";
+        return "redirect:/laundry-item/list";
     }
 
     // http://localhost:8080/laundry-item/{laundryItemId}/update
@@ -94,6 +102,6 @@ public class LaundryItemController {
     @PostMapping("/laundry-item/{laundryItemId}/delete")
     public String delete(@PathVariable Long laundryItemId) {
         service.delete(laundryItemId);
-        return "redirect:/laundry-item";
+        return "redirect:/laundry-item/list";
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemRepository.java
@@ -1,5 +1,7 @@
 package org.example.clean4u.laundryItem;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,12 +13,15 @@ public interface LaundryItemRepository extends JpaRepository<LaundryItem, Long> 
     @Query("SELECT li FROM LaundryItem li ORDER BY li.createdAt DESC")
     List<LaundryItem> findAllOrderByCreatedAtDesc();
 
-    List<LaundryItem> findByCategory(LaundryCategory category);
+    @Query("SELECT li FROM LaundryItem li ORDER BY li.createdAt DESC")
+    Page<LaundryItem> findAllOrderByCreatedAtDesc(Pageable pageable);
 
-    List<LaundryItem> findByNameContaining(String name);
+    Page<LaundryItem> findByCategory(LaundryCategory category, Pageable pageable);
+
+    Page<LaundryItem> findByNameContaining(String name, Pageable pageable);
 
     @Query("SELECT li FROM LaundryItem li WHERE li.name LIKE CONCAT('%', :name, '%') AND li.category = :category ORDER BY li.createdAt DESC")
-    List<LaundryItem> findByNameContainingAndCategory(@Param("category") LaundryCategory category, @Param("name") String name);
+    Page<LaundryItem> findByNameContainingAndCategory(@Param("category") LaundryCategory category, @Param("name") String name, Pageable pageable);
 
     Optional<LaundryItem> findByName(String name);
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemService.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemService.java
@@ -4,6 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.clean4u._core.errors.exception.Exception400;
 import org.example.clean4u._core.errors.exception.Exception404;
+import org.example.clean4u._core.response.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,24 +69,31 @@ public class LaundryItemService {
         repository.deleteById(laundryItemId);
     }
 
-    public List<LaundryItemResponse.ListDTO> findByCategory(LaundryCategory category) {
-        List<LaundryItem> laundryItemList = repository.findByCategory(category);
-        return laundryItemList.stream()
-                .map(LaundryItemResponse.ListDTO::new)
-                .collect(Collectors.toList());
-    }
+    public PageResponse<LaundryItemResponse.ListDTO> laundryItemList(
+            int page,
+            int size,
+            LaundryCategory category,
+            String name
+    ) {
+        int validPage = Math.max(0, page);
+        int validSize = Math.max(1, Math.min(50, size));
 
-    public List<LaundryItemResponse.ListDTO> findByNameContaining(String name) {
-        List<LaundryItem> laundryItemList = repository.findByNameContaining(name);
-        return laundryItemList.stream()
-                .map(LaundryItemResponse.ListDTO::new)
-                .collect(Collectors.toList());
-    }
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(validPage, validSize, sort);
 
-    public List<LaundryItemResponse.ListDTO> findByNameContainingAndCategory(LaundryCategory category, String name) {
-        List<LaundryItem> laundryItemList = repository.findByNameContainingAndCategory(category, name);
-        return laundryItemList.stream()
-                .map(LaundryItemResponse.ListDTO::new)
-                .collect(Collectors.toList());
+        Page<LaundryItem> laundryItemPage;
+        boolean hasName = name != null && !name.isBlank();
+
+        if (category != null && hasName) {
+            laundryItemPage = repository.findByNameContainingAndCategory(category, name, pageable);
+        } else if (category != null) {
+            laundryItemPage = repository.findByCategory(category, pageable);
+        } else if (hasName) {
+            laundryItemPage = repository.findByNameContaining(name, pageable);
+        } else {
+            laundryItemPage = repository.findAllOrderByCreatedAtDesc(pageable);
+        }
+
+        return new PageResponse<>(laundryItemPage, LaundryItemResponse.ListDTO::new);
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionController.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionController.java
@@ -1,7 +1,10 @@
 package org.example.clean4u.laundryOption;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.clean4u._core.response.PageResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,29 +20,38 @@ public class LaundryOptionController {
 
     private final LaundryOptionService service;
 
-    // http://localhost:8080/laundry-option
-    @GetMapping("/laundry-option")
+    // http://localhost:8080/laundry-option/list
+    @GetMapping("/laundry-option/list")
     public String laundryOptionList(
             Model model,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "9") int size,
             @RequestParam(required = false) String name,
-            @RequestParam(required = false) Boolean isActive
+            @RequestParam(required = false) Boolean isActive,
+            HttpSession session,
+            HttpServletRequest request
     ) {
-        List<LaundryOptionResponse.ListDTO> laundryOptionList;
 
-        if (name != null && !name.isBlank() && isActive != null) {
-            laundryOptionList = service.findByNameContainingAndIsActive(name, isActive);
-        } else if (name != null && !name.isBlank()) {
-            laundryOptionList = service.findByNameContaining(name);
-        } else if (isActive != null) {
-            laundryOptionList = service.findByIsActive(isActive);
-        } else {
-            laundryOptionList = service.getAllLaundryOptions();
+        int pageIndex = Math.max(0, page - 1);
+
+        String queryString = request.getQueryString();
+
+        if (queryString != null) {
+            queryString = queryString.replaceAll("(&page=\\d+)", "");
+            queryString = queryString.replaceAll("(&size=\\d+)", "");
+            if (!queryString.isBlank()) {
+                queryString = "&" + queryString;
+            }
         }
-        model.addAttribute("laundryOptionList", laundryOptionList);
+
+        PageResponse<LaundryOptionResponse.ListDTO> laundryOptionListPage = service.laundryOptionList(pageIndex, size, isActive, name);
+        model.addAttribute("laundryOptionList", laundryOptionListPage.getContent());
+        model.addAttribute("laundryOptionPage", laundryOptionListPage);
         model.addAttribute("name", name == null ? "" : name);
         model.addAttribute("isActive", isActive);
         model.addAttribute("isActiveTrue", Boolean.TRUE.equals(isActive));
         model.addAttribute("isActiveFalse", Boolean.FALSE.equals(isActive));
+        model.addAttribute("queryString", queryString);
         return "laundryOption/list-form";
     }
 
@@ -62,7 +74,7 @@ public class LaundryOptionController {
     @PostMapping("/laundry-option/save")
     public String saveProc(@Valid LaundryOptionRequest.SaveDTO saveDTO) {
         service.save(saveDTO);
-        return "redirect:/laundry-option";
+        return "redirect:/laundry-option/list";
     }
 
     // http://localhost:8080/laundry-option/{laundryOptionId}/update

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionRepository.java
@@ -1,5 +1,7 @@
 package org.example.clean4u.laundryOption;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,11 +12,14 @@ public interface LaundryOptionRepository extends JpaRepository<LaundryOption, Lo
     @Query("SELECT lo FROM LaundryOption lo ORDER BY lo.createdAt DESC")
     List<LaundryOption> findAllOrderByCreatedAtDesc();
 
-    List<LaundryOption> findByIsActive(Boolean isActive);
+    @Query("SELECT lo FROM LaundryOption lo ORDER BY lo.createdAt DESC")
+    Page<LaundryOption> findAllOrderByCreatedAtDesc(Pageable pageable);
 
-    List<LaundryOption> findByNameContaining(String name);
+    Page<LaundryOption> findByIsActive(Boolean isActive, Pageable pageable);
 
-    List<LaundryOption> findByNameContainingAndIsActive(String name, Boolean isActive);
+    Page<LaundryOption> findByNameContaining(String name, Pageable pageable);
+
+    Page<LaundryOption> findByNameContainingAndIsActive(String name, Boolean isActive, Pageable pageable);
 
     Optional<LaundryOption> findByName(String name);
 }

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionService.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionService.java
@@ -4,6 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.clean4u._core.errors.exception.Exception400;
 import org.example.clean4u._core.errors.exception.Exception404;
+import org.example.clean4u._core.response.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,24 +76,30 @@ public class LaundryOptionService {
         laundryOption.updateIsActive(true);
     }
 
-    public List<LaundryOptionResponse.ListDTO> findByIsActive(Boolean isActive) {
-        List<LaundryOption> laundryOptionList = repository.findByIsActive(isActive);
-        return laundryOptionList.stream()
-                .map(LaundryOptionResponse.ListDTO::new)
-                .collect(Collectors.toList());
-    }
+    public PageResponse<LaundryOptionResponse.ListDTO> laundryOptionList(
+            int page,
+            int size,
+            Boolean isActive,
+            String name
+    ) {
+        int validPage = Math.max(0, page);
+        int validSize = Math.max(1, Math.min(50, size));
 
-    public List<LaundryOptionResponse.ListDTO> findByNameContaining(String name) {
-        List<LaundryOption> laundryOptionList = repository.findByNameContaining(name);
-        return laundryOptionList.stream()
-                .map(LaundryOptionResponse.ListDTO::new)
-                .collect(Collectors.toList());
-    }
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(validPage, validSize, sort);
 
-    public List<LaundryOptionResponse.ListDTO> findByNameContainingAndIsActive(String name, Boolean isActive) {
-        List<LaundryOption> laundryOptionList = repository.findByNameContainingAndIsActive(name, isActive);
-        return laundryOptionList.stream()
-                .map(LaundryOptionResponse.ListDTO::new)
-                .collect(Collectors.toList());
+        Page<LaundryOption> laundryOptionPage;
+        boolean hasName = name != null && !name.isBlank();
+
+        if (hasName && isActive != null) {
+            laundryOptionPage = repository.findByNameContainingAndIsActive(name, isActive, pageable);
+        } else if (hasName) {
+            laundryOptionPage = repository.findByNameContaining(name, pageable);
+        } else if (isActive != null) {
+            laundryOptionPage = repository.findByIsActive(isActive, pageable);
+        } else {
+            laundryOptionPage = repository.findAllOrderByCreatedAtDesc(pageable);
+        }
+        return new PageResponse<>(laundryOptionPage, LaundryOptionResponse.ListDTO::new);
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
@@ -1,7 +1,10 @@
 package org.example.clean4u.supplyItem;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.clean4u._core.response.PageResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,42 +12,43 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.List;
-
 @Controller
 @RequiredArgsConstructor
 public class SupplyItemController {
 
     private final SupplyItemService service;
 
-    // http://localhost:8080/supply-item
-    @GetMapping("/supply-item")
+    // http://localhost:8080/supply-item/list
+    @GetMapping("/supply-item/list")
     public String supplyItemList(
             Model model,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "9") int size,
             @RequestParam(required = false) String name,
-            @RequestParam(required = false) Boolean lowStock
+            @RequestParam(required = false) Boolean lowStock,
+            HttpSession session,
+            HttpServletRequest request
     ) {
-        List<SupplyItemResponse.ListDTO> supplyItemList;
-        boolean hasName = name != null && !name.isBlank();
+        int pageIndex = Math.max(0, page - 1);
 
-        if (hasName && lowStock != null && lowStock) {
-            supplyItemList = service.findByNameContainingAndLowStock(name);
-        } else if (hasName && lowStock != null && !lowStock) {
-            supplyItemList = service.findByNameContainingAndSafetyStock(name);
-        } else if (hasName) {
-            supplyItemList = service.findByNameContaining(name);
-        } else if (lowStock != null && lowStock) {
-            supplyItemList = service.findLowStockItems();
-        } else if (lowStock != null && !lowStock) {
-            supplyItemList = service.findSafetyStockItems();
-        } else {
-            supplyItemList = service.getAllSupplyItems();
+        String queryString = request.getQueryString();
+
+        if (queryString != null) {
+            queryString = queryString.replaceAll("(&page=\\d+)", "");
+            queryString = queryString.replaceAll("(&size=\\d+)", "");
+            if (!queryString.isBlank()) {
+                queryString = "&" + queryString;
+            }
         }
-        model.addAttribute("supplyItemList", supplyItemList);
+
+        PageResponse<SupplyItemResponse.ListDTO> supplyItemListPage = service.supplyItemList(pageIndex, size, lowStock, name);
+        model.addAttribute("supplyItemList", supplyItemListPage.getContent());
+        model.addAttribute("supplyItemPage", supplyItemListPage);
         model.addAttribute("name", name == null ? "" : name);
         model.addAttribute("lowStock", lowStock);
         model.addAttribute("lowStockTrue", Boolean.TRUE.equals(lowStock));
         model.addAttribute("lowStockFalse", Boolean.FALSE.equals(lowStock));
+        model.addAttribute("queryString", queryString);
         return "supplyItem/list-form";
     }
 
@@ -67,7 +71,7 @@ public class SupplyItemController {
     @PostMapping("/supply-item/save")
     public String saveProc(@Valid SupplyItemRequest.SaveDTO saveDTO) {
         service.save(saveDTO);
-        return "redirect:/supply-item";
+        return "redirect:/supply-item/list";
     }
 
     // http://localhost:8080/supply-item/{supplyItemId}/update

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemRepository.java
@@ -1,5 +1,7 @@
 package org.example.clean4u.supplyItem;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,19 +13,22 @@ public interface SupplyItemRepository extends JpaRepository<SupplyItem, Long> {
     @Query("SELECT si FROM SupplyItem si ORDER BY si.createdAt DESC")
     List<SupplyItem> findAllOrderByCreatedAtDesc();
 
+    @Query("SELECT si FROM SupplyItem si ORDER BY si.createdAt DESC")
+    Page<SupplyItem> findAllOrderByCreatedAtDesc(Pageable pageable);
+
     @Query("SELECT si FROM SupplyItem si WHERE si.stockQuantity <= si.safetyStock ORDER BY si.createdAt DESC")
-    List<SupplyItem> findLowStockItems();
+    Page<SupplyItem> findLowStockItems(Pageable pageable);
 
     @Query("SELECT si FROM SupplyItem si WHERE si.stockQuantity > si.safetyStock ORDER BY si.createdAt DESC")
-    List<SupplyItem> findSafetyStockItems();
+    Page<SupplyItem> findSafetyStockItems(Pageable pageable);
 
-    List<SupplyItem> findByNameContaining(String name);
+    Page<SupplyItem> findByNameContaining(String name, Pageable pageable);
 
     @Query("SELECT si FROM SupplyItem si WHERE si.name LIKE CONCAT('%', :name, '%') AND si.stockQuantity <= si.safetyStock ORDER BY si.createdAt DESC")
-    List<SupplyItem> findByNameContainingAndLowStock(@Param("name") String name);
+    Page<SupplyItem> findByNameContainingAndLowStock(@Param("name") String name, Pageable pageable);
 
     @Query("SELECT si FROM SupplyItem si WHERE si.name LIKE CONCAT('%', :name, '%') AND si.stockQuantity > si.safetyStock ORDER BY si.createdAt DESC")
-    List<SupplyItem> findByNameContainingAndSafetyStock(@Param("name") String name);
+    Page<SupplyItem> findByNameContainingAndSafetyStock(@Param("name") String name, Pageable pageable);
 
     Optional<SupplyItem> findByName(String name);
 }

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemService.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemService.java
@@ -4,6 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.clean4u._core.errors.exception.Exception400;
 import org.example.clean4u._core.errors.exception.Exception404;
+import org.example.clean4u._core.response.PageResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -72,38 +77,34 @@ public class SupplyItemService {
         supplyItem.updateIsActive(true);
     }
 
-    public List<SupplyItemResponse.ListDTO> findByNameContaining(String name) {
-        List<SupplyItem> supplyItemList = repository.findByNameContaining(name);
-        return supplyItemList.stream()
-                .map(SupplyItemResponse.ListDTO::new)
-                .collect(Collectors.toList());
-    }
+    public PageResponse<SupplyItemResponse.ListDTO> supplyItemList(
+            int page,
+            int size,
+            Boolean lowStock,
+            String name
+    ) {
+        int validPage = Math.max(0, page);
+        int validSize = Math.max(1, Math.min(50, size));
 
-    public List<SupplyItemResponse.ListDTO> findLowStockItems() {
-        List<SupplyItem> supplyItemList = repository.findLowStockItems();
-        return supplyItemList.stream()
-                .map(SupplyItemResponse.ListDTO::new)
-                .collect(Collectors.toList());
-    }
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(validPage, validSize, sort);
 
-    public List<SupplyItemResponse.ListDTO> findSafetyStockItems() {
-        List<SupplyItem> supplyItemList = repository.findSafetyStockItems();
-        return supplyItemList.stream()
-                .map(SupplyItemResponse.ListDTO::new)
-                .collect(Collectors.toList());
-    }
+        Page<SupplyItem> supplyItemPage;
+        boolean hasName = name != null && !name.isBlank();
 
-    public List<SupplyItemResponse.ListDTO> findByNameContainingAndLowStock(String name) {
-        List<SupplyItem> supplyItemList = repository.findByNameContainingAndLowStock(name);
-        return supplyItemList.stream()
-                .map(SupplyItemResponse.ListDTO::new)
-                .collect(Collectors.toList());
-    }
-
-    public List<SupplyItemResponse.ListDTO> findByNameContainingAndSafetyStock(String name) {
-        List<SupplyItem> supplyItemList = repository.findByNameContainingAndSafetyStock(name);
-        return supplyItemList.stream()
-                .map(SupplyItemResponse.ListDTO::new)
-                .collect(Collectors.toList());
+        if (hasName && lowStock != null && lowStock) {
+            supplyItemPage = repository.findByNameContainingAndLowStock(name, pageable);
+        } else if (hasName && lowStock != null && !lowStock) {
+            supplyItemPage = repository.findByNameContainingAndSafetyStock(name, pageable);
+        } else if (hasName) {
+            supplyItemPage = repository.findByNameContaining(name, pageable);
+        } else if (lowStock != null && lowStock) {
+            supplyItemPage = repository.findLowStockItems(pageable);
+        } else if (lowStock != null && !lowStock) {
+            supplyItemPage = repository.findSafetyStockItems(pageable);
+        } else {
+            supplyItemPage = repository.findAllOrderByCreatedAtDesc(pageable);
+        }
+        return new PageResponse<>(supplyItemPage, SupplyItemResponse.ListDTO::new);
     }
 }

--- a/clean4u/src/main/resources/static/base.css
+++ b/clean4u/src/main/resources/static/base.css
@@ -14,6 +14,8 @@
     --color-light-gray: #e0e0e0;
     --color-black: #000000;
 
+    --text-gray: #64748B;
+
     --status-received: #FFB74D;
     --status-washing: #81D4FA;
     --status-drying: #1EAABE;

--- a/clean4u/src/main/resources/static/list.css
+++ b/clean4u/src/main/resources/static/list.css
@@ -11,7 +11,7 @@
     width: 100%;
     max-width: 1280px;
     margin: 0 auto;
-    padding: 2rem 4rem;
+    padding: 2rem 4rem 0 4rem;
     flex: 1;
 }
 

--- a/clean4u/src/main/resources/static/pageLink.css
+++ b/clean4u/src/main/resources/static/pageLink.css
@@ -7,14 +7,16 @@
 }
 
 .page-btn {
-    min-width: 38px;
-    height: 38px;
-    padding: 0 0.9rem;
-    border-radius: 10px;
-    color: var(--color-gray);
+    min-width: 42px;
+    height: 42px;
+    padding: 0 0.75rem;
+    border-radius: 8px;
+    color: var(--text-gray);
+    font-size: 0.95rem;
     display: flex;
     justify-content: center;
     align-items: center;
+    border: 1px solid transparent;
 }
 
 .page-btn a {
@@ -26,11 +28,13 @@
 }
 
 .page-btn.active {
-    background: var(--background-blue);
-    opacity: 1;
+    background: rgba(79, 195, 247, 0.2);
     font-weight: 700;
-    border: 1px solid var(--color-blue);
-    color: var(--color-blue);
+    border: 2px solid var(--color-blue);
+}
+
+.pagination-link i {
+    font-size: 0.9rem;
 }
 
 .page-btn.disabled {
@@ -38,6 +42,6 @@
     opacity: 0.3;
 }
 
-.page-btn.active a {
-    color: var(--color-blue);
+.page-btn.active {
+    color: #0f9eff;
 }

--- a/clean4u/src/main/resources/templates/laundryItem/list-form.mustache
+++ b/clean4u/src/main/resources/templates/laundryItem/list-form.mustache
@@ -2,7 +2,7 @@
 
 {{> layout/background}}
 
-<!-- http://localhost:8080/laundry-item -->
+<!-- http://localhost:8080/laundry-item/list -->
 <div class="content-section">
     <div class="container">
         <div class="header-container">
@@ -14,7 +14,7 @@
                     <span>+</span>생성
                 </a>
             </div>
-            <form class="search-wrapper" method="get" action="/laundry-item">
+            <form class="search-wrapper" method="get" action="/laundry-item/list">
                 <div class="search-input-box">
                     <i class="fa-solid fa-search"></i>
                     <input class="search-input" type="text" placeholder="검색어를 입력해주세요." value="{{name}}" name="name">
@@ -23,7 +23,8 @@
                     <input type="hidden" name="category" id="category" {{#category}}value="{{category}}" {{/category}}>
                     <div class="category-select" {{#category}}data-selected="{{category}}" {{/category}}>
                         <i class="fa-solid fa-list"></i>
-                        <span class="category-selected">{{#category}}{{category}}{{/category}}{{^category}}전체 카테고리{{/category}}</span>
+                        <span class="category-selected">{{#category}}{{category}}{{/category}}{{^category}}
+                            전체 카테고리{{/category}}</span>
                         <i class="fa-solid fa-chevron-down"></i>
                     </div>
                     <ul class="category-dropdown">
@@ -66,5 +67,41 @@
         {{/laundryItemList}}
     </div>
 </div>
+<ul class="pagination">
+    {{#laundryItemPage.previousPageNumber}}
+        <li class="page-btn">
+            <a href="/laundry-item/list?page={{laundryItemPage.previousPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}
+            ">
+            <i class="fa-solid fa-chevron-right"></i>
+            </a>
+        </li>
+    {{/laundryItemPage.previousPageNumber}}
+    {{^laundryItemPage.previousPageNumber}}
+        <li class="page-btn disabled">
+            <i class="fa-solid fa-chevron-left"></i>
+        </li>
+    {{/laundryItemPage.previousPageNumber}}
+
+    {{#laundryItemPage.pageLinks}}
+        <li class="page-btn {{#active}}active{{/active}}">
+            <a href="/laundry-item/list?page={{displayNumber}}
+            &size={{laundryItemPage.size}}{{#queryString}}{{queryString}}{{/queryString}}">{{displayNumber}}</a>
+        </li>
+    {{/laundryItemPage.pageLinks}}
+
+    {{#laundryItemPage.nextPageNumber}}
+        <li class="page-btn">
+            <a href="/laundry-item/list?page={{laundryItemPage.nextPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}
+            ">
+            <i class="fa-solid fa-chevron-right"></i>
+            </a>
+        </li>
+    {{/laundryItemPage.nextPageNumber}}
+    {{^laundryItemPage.nextPageNumber}}
+        <li class="page-btn disabled">
+            <i class="fa-solid fa-chevron-right"></i>
+        </li>
+    {{/laundryItemPage.nextPageNumber}}
+</ul>
 
 {{> layout/footer}}

--- a/clean4u/src/main/resources/templates/laundryOption/list-form.mustache
+++ b/clean4u/src/main/resources/templates/laundryOption/list-form.mustache
@@ -2,7 +2,7 @@
 
 {{> layout/background}}
 
-<!-- http://localhost:8080/laundry-option -->
+<!-- http://localhost:8080/laundry-option/list -->
 <div class="content-section">
     <div class="container">
         <div class="header-container">
@@ -14,7 +14,7 @@
                     <span>+</span>생성
                 </a>
             </div>
-            <form class="search-wrapper" method="get" action="/laundry-option">
+            <form class="search-wrapper" method="get" action="/laundry-option/list">
                 <div class="search-input-box">
                     <i class="fa-solid fa-search"></i>
                     <input class="search-input" type="text" placeholder="검색어를 입력해주세요." value="{{name}}" name="name">
@@ -61,5 +61,38 @@
         {{/laundryOptionList}}
     </div>
 </div>
+<ul class="pagination">
+    {{#laundryOptionPage.previousPageNumber}}
+        <li class="page-btn">
+            <a href="/laundry-option/list?page={{laundryOptionPage.previousPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}">
+                <i class="fa-solid fa-chevron-left"></i>
+            </a>
+        </li>
+    {{/laundryOptionPage.previousPageNumber}}
+    {{^laundryOptionPage.previousPageNumber}}
+        <li class="page-btn disabled">
+            <i class="fa-solid fa-chevron-left"></i>
+        </li>
+    {{/laundryOptionPage.previousPageNumber}}
+
+    {{#laundryOptionPage.pageLinks}}
+        <li class="page-btn {{#active}}active{{/active}}">
+            <a href="/laundry-option/list?page={{displayNumber}}&size={{laundryOptionPage.size}}{{#queryString}}{{queryString}}{{/queryString}}">{{displayNumber}}</a>
+        </li>
+    {{/laundryOptionPage.pageLinks}}
+
+    {{#laundryOptionPage.nextPageNumber}}
+        <li class="page-btn">
+            <a href="/laundry-option/list?page={{laundryOptionPage.nextPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}">
+                <i class="fa-solid fa-chevron-right"></i>
+            </a>
+        </li>
+    {{/laundryOptionPage.nextPageNumber}}
+    {{^laundryOptionPage.nextPageNumber}}
+        <li class="page-btn disabled">
+            <i class="fa-solid fa-chevron-right"></i>
+        </li>
+    {{/laundryOptionPage.nextPageNumber}}
+</ul>
 
 {{> layout/footer}}

--- a/clean4u/src/main/resources/templates/layout/header.mustache
+++ b/clean4u/src/main/resources/templates/layout/header.mustache
@@ -88,13 +88,13 @@
                         </span>
                         <ul class="dropdown-menu">
                             <li>
-                                <a href="/laundry-item" class="dropdown-item">
+                                <a href="/laundry-item/list" class="dropdown-item">
                                     <i class="fa-solid fa-shirt"></i>
                                     세탁물 관리
                                 </a>
                             </li>
                             <li>
-                                <a href="/laundry-option" class="dropdown-item">
+                                <a href="/laundry-option/list" class="dropdown-item">
                                     <i class="fa-solid fa-tag"></i>
                                     세탁 옵션 관리
                                 </a>
@@ -102,7 +102,7 @@
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/supply-item">
+                        <a class="nav-link" href="/supply-item/list">
                             <i class="fa-solid fa-box"></i>자재 관리
                         </a>
                     </li>

--- a/clean4u/src/main/resources/templates/order/list-form.mustache
+++ b/clean4u/src/main/resources/templates/order/list-form.mustache
@@ -112,13 +112,13 @@
         {{#orderPage.previousPageNumber}}
             <li class="page-btn">
                 <a href="/order/list?page={{orderPage.previousPageNumber}}">
-                    <
+                <i class="fa-solid fa-chevron-left"></i>
                 </a>
             </li>
         {{/orderPage.previousPageNumber}}
         {{^orderPage.previousPageNumber}}
             <li class="page-btn disabled">
-                <
+                <i class="fa-solid fa-chevron-left"></i>
             </li>
         {{/orderPage.previousPageNumber}}
 
@@ -131,13 +131,13 @@
         {{#orderPage.NextPageNumber}}
             <li class="page-btn">
                 <a href="/order/list?page={{orderPage.NextPageNumber}}">
-                    >
+                <i class="fa-solid fa-chevron-right"></i>
                 </a>
             </li>
         {{/orderPage.NextPageNumber}}
         {{^orderPage.NextPageNumber}}
             <li class="page-btn disabled">
-                >
+                <i class="fa-solid fa-chevron-right"></i>
             </li>
         {{/orderPage.NextPageNumber}}
     </ul>

--- a/clean4u/src/main/resources/templates/supplyItem/list-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItem/list-form.mustache
@@ -2,8 +2,7 @@
 
 {{> layout/background}}
 
-<!-- http://localhost:8080/supply-item -->
-<!-- http://localhost:8080/login -->
+<!-- http://localhost:8080/supply-item/list -->
 <div class="content-section">
     <div class="container">
         <div class="header-container">
@@ -15,7 +14,7 @@
                     <span>+</span>생성
                 </a>
             </div>
-            <form class="search-wrapper" method="get" action="/supply-item">
+            <form class="search-wrapper" method="get" action="/supply-item/list">
                 <div class="search-input-box">
                     <i class="fa-solid fa-search"></i>
                     <input class="search-input" type="text" placeholder="검색어를 입력해주세요." value="{{name}}" name="name">
@@ -73,5 +72,39 @@
         {{/supplyItemList}}
     </div>
 </div>
+<ul class="pagination">
+    {{#supplyItemPage.previousPageNumber}}
+        <li class="page-btn">
+            <a href="/supply-item/list?page={{supplyItemPage.previousPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}">
+                <i class="fa-solid fa-chevron-left"></i>
+            </a>
+        </li>
+    {{/supplyItemPage.previousPageNumber}}
+    {{^supplyItemPage.previousPageNumber}}
+        <li class="page-btn disabled">
+            <i class="fa-solid fa-chevron-left"></i>
+        </li>
+    {{/supplyItemPage.previousPageNumber}}
+
+    {{#supplyItemPage.pageLinks}}
+        <li class="page-btn {{#active}}active{{/active}}">
+            <a href="/supply-item/list?page={{displayNumber}}&size={{supplyItemPage.size}}{{#queryString}}{{queryString}}{{/queryString}}">{{displayNumber}}</a>
+        </li>
+    {{/supplyItemPage.pageLinks}}
+
+    {{#supplyItemPage.nextPageNumber}}
+        <li class="page-btn">
+            <a href="/supply-item/list?page={{supplyItemPage.nextPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}">
+            <i class="fa-solid fa-chevron-right"></i>
+            </a>
+        </li>
+    {{/supplyItemPage.nextPageNumber}}
+    {{^supplyItemPage.nextPageNumber}}
+        <li class="page-btn disabled">
+            <i class="fa-solid fa-chevron-right"></i>
+        </li>
+    {{/supplyItemPage.nextPageNumber}}
+</ul>
+
 
 {{> layout/footer}}


### PR DESCRIPTION
## 변경 배경
각 도메인의 리스트 페이지에 페이징을 적용합니다.

## 주요 변경 사항
- LaundryItem 리스트 페이지 페이징 UI 연동(FE)
- LaundryItem 목록 페이징 적용(BE)
- SupplyItem 리스트 페이지 페이징 UI 연동(FE)
- SupplyItem 목록 페이징 적용(BE)
- 목록 화면 및 페이징 스타일 조정(FE)

## 기술 스택 및 구현 방식
- FE, BE 작업
- Spring Boot, Spring Data JPA, Mustache, CSS, JavaScript
- 페이징 UI 및 백엔드 페이징 처리

## 영향 범위
- [x] Frontend
- [x] Backend
- [ ] Database
- [x] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 페이징 기능 정상 동작 확인

### 테스트 방법
1. 각 도메인 리스트 페이지 페이징 확인
2. 페이징 UI 동작 확인
3. 페이징 API 동작 확인

## 관련 이슈
- 이슈 번호: #277
- Closes #277