### PR TITLE
feat: 각 도메인 가격 및 수량에 PriceUtil 적용(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemResponse.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemResponse.java
@@ -2,6 +2,7 @@ package org.example.clean4u.laundryItem;
 
 import lombok.Data;
 import org.example.clean4u._core.utils.DateUtil;
+import org.example.clean4u._core.utils.PriceUtil;
 
 public class LaundryItemResponse {
     @Data
@@ -9,7 +10,7 @@ public class LaundryItemResponse {
         private Long id;
         private String name;
         private LaundryCategory category;
-        private Integer basePrice;
+        private String basePrice;
         private String description;
         private String icon;
 
@@ -17,7 +18,7 @@ public class LaundryItemResponse {
             this.id = laundryItem.getId();
             this.name = laundryItem.getName();
             this.category = laundryItem.getCategory();
-            this.basePrice = laundryItem.getBasePrice();
+            this.basePrice = laundryItem.getBasePrice() != null ? PriceUtil.format(laundryItem.getBasePrice()) : null ;
             this.description = laundryItem.getDescription();
             this.icon = laundryItem.getIcon();
         }
@@ -28,7 +29,7 @@ public class LaundryItemResponse {
         private Long id;
         private String name;
         private LaundryCategory category;
-        private Integer basePrice;
+        private String basePrice;
         private String description;
         private String createdAt;
         private String updatedAt;
@@ -38,7 +39,7 @@ public class LaundryItemResponse {
             this.id = laundryItem.getId();
             this.name = laundryItem.getName();
             this.category = laundryItem.getCategory();
-            this.basePrice = laundryItem.getBasePrice();
+            this.basePrice = laundryItem.getBasePrice() != null ? PriceUtil.format(laundryItem.getBasePrice()) : null;
             this.description = laundryItem.getDescription();
             this.createdAt = DateUtil.timestampFormat(laundryItem.getCreatedAt());
             this.updatedAt = DateUtil.timestampFormat(laundryItem.getUpdatedAt());

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionResponse.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionResponse.java
@@ -2,20 +2,21 @@ package org.example.clean4u.laundryOption;
 
 import lombok.Data;
 import org.example.clean4u._core.utils.DateUtil;
+import org.example.clean4u._core.utils.PriceUtil;
 
 public class LaundryOptionResponse {
     @Data
     public static class ListDTO {
         private Long id;
         private String name;
-        private Integer extraPrice;
+        private String extraPrice;
         private String description;
         private Boolean isActive;
 
         public ListDTO(LaundryOption laundryOption) {
             this.id = laundryOption.getId();
             this.name = laundryOption.getName();
-            this.extraPrice = laundryOption.getExtraPrice();
+            this.extraPrice = laundryOption.getExtraPrice() != null ? PriceUtil.format(laundryOption.getExtraPrice()) : null;
             this.description = laundryOption.getDescription();
             this.isActive = laundryOption.getIsActive();
         }
@@ -25,7 +26,7 @@ public class LaundryOptionResponse {
     public static class DetailDTO {
         private Long id;
         private String name;
-        private Integer extraPrice;
+        private String extraPrice;
         private String description;
         private Boolean isActive;
         private String createdAt;
@@ -34,7 +35,7 @@ public class LaundryOptionResponse {
         public DetailDTO(LaundryOption laundryOption) {
             this.id = laundryOption.getId();
             this.name = laundryOption.getName();
-            this.extraPrice = laundryOption.getExtraPrice();
+            this.extraPrice = laundryOption.getExtraPrice() != null ? PriceUtil.format(laundryOption.getExtraPrice()) : null;
             this.description = laundryOption.getDescription();
             this.isActive = laundryOption.getIsActive();
             this.createdAt = DateUtil.timestampFormat(laundryOption.getCreatedAt());

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemResponse.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemResponse.java
@@ -2,6 +2,7 @@ package org.example.clean4u.supplyItem;
 
 import lombok.Data;
 import org.example.clean4u._core.utils.DateUtil;
+import org.example.clean4u._core.utils.PriceUtil;
 
 public class SupplyItemResponse {
     @Data
@@ -9,8 +10,8 @@ public class SupplyItemResponse {
         private Long id;
         private String name;
         private String unit;
-        private Integer stockQuantity;
-        private Integer safetyStock;
+        private String stockQuantity;
+        private String safetyStock;
         private Boolean isLowStock;
         private Boolean isActive;
 
@@ -18,8 +19,8 @@ public class SupplyItemResponse {
             this.id = supplyItem.getId();
             this.name = supplyItem.getName();
             this.unit = supplyItem.getUnit();
-            this.stockQuantity = supplyItem.getStockQuantity();
-            this.safetyStock = supplyItem.getSafetyStock();
+            this.stockQuantity = supplyItem.getStockQuantity() != null ? PriceUtil.format(supplyItem.getStockQuantity()) : null;
+            this.safetyStock = supplyItem.getSafetyStock() != null ? PriceUtil.format(supplyItem.getSafetyStock()) : null;
             this.isLowStock = supplyItem.getStockQuantity() <= supplyItem.getSafetyStock();
             this.isActive = supplyItem.getIsActive();
         }
@@ -30,8 +31,8 @@ public class SupplyItemResponse {
         private Long id;
         private String name;
         private String unit;
-        private Integer stockQuantity;
-        private Integer safetyStock;
+        private String stockQuantity;
+        private String safetyStock;
         private Boolean isLowStock;
         private Boolean isActive;
         private String createdAt;
@@ -41,8 +42,8 @@ public class SupplyItemResponse {
             this.id = supplyItem.getId();
             this.name = supplyItem.getName();
             this.unit = supplyItem.getUnit();
-            this.stockQuantity = supplyItem.getStockQuantity();
-            this.safetyStock = supplyItem.getSafetyStock();
+            this.stockQuantity = supplyItem.getStockQuantity() != null ? PriceUtil.format(supplyItem.getStockQuantity()) : null;
+            this.safetyStock = supplyItem.getSafetyStock() != null ? PriceUtil.format(supplyItem.getSafetyStock()) : null;
             this.isLowStock = supplyItem.getStockQuantity() <= supplyItem.getSafetyStock();
             this.isActive = supplyItem.getIsActive();
             this.createdAt = DateUtil.timestampFormat(supplyItem.getCreatedAt());


### PR DESCRIPTION
## 변경 배경
각 도메인의 가격 및 수량에 PriceUtil을 적용합니다.

## 주요 변경 사항
- LaundryItem 가격 응답에 PriceUtil 적용(BE)
- LaundryOption 가격 응답에 PriceUtil 적용(BE)
- SupplyItem 수량 응답에 PriceUtil 적용(BE)

## 기술 스택 및 구현 방식
- BE 작업
- Spring Boot, PriceUtil 유틸리티
- 가격 및 수량 포맷팅 적용

## 영향 범위
- [ ] Frontend
- [x] Backend
- [ ] Database
- [x] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 가격/수량 포맷팅 정상 동작 확인

### 테스트 방법
1. 각 도메인의 가격/수량 포맷팅 확인
2. API 응답 확인
3. 다양한 값에 대한 포맷팅 확인

## 관련 이슈
- 이슈 번호: #280
- Closes #280