### PR TITLE
fix: 카테고리 드롭다운 ID 중복 분리(FE)

### DIFF
--- a/clean4u/src/main/resources/templates/laundryOption/list-form.mustache
+++ b/clean4u/src/main/resources/templates/laundryOption/list-form.mustache
@@ -23,7 +23,7 @@
                     <input class="search-input" type="text" placeholder="검색어를 입력해주세요." value="{{name}}" name="name">
                 </div>
                 <div class="update-value category">
-                    <input type="hidden" name="isActive" id="category" {{#isActive}}value="{{isActive}}" {{/isActive}}>
+                    <input type="hidden" name="isActive" id="isActive" {{#isActive}}value="{{isActive}}" {{/isActive}}>
                     <div class="category-select" {{#isActive}}data-selected="{{isActive}}" {{/isActive}}>
                         <i class="fa-solid fa-list"></i>
                         <span class="category-selected">

--- a/clean4u/src/main/resources/templates/order/list-form.mustache
+++ b/clean4u/src/main/resources/templates/order/list-form.mustache
@@ -38,7 +38,7 @@
                                 placeholder="연락처">
                     </div>
                     <div class="update-value category">
-                        <input type="hidden" name="status" id="category">
+                        <input type="hidden" name="status" id="status">
                         <div class="category-select">
                             <i class="fa-solid fa-info-circle"></i>
                             <span class="category-selected">

--- a/clean4u/src/main/resources/templates/orderStatusHistory/list-form.mustache
+++ b/clean4u/src/main/resources/templates/orderStatusHistory/list-form.mustache
@@ -33,7 +33,7 @@
                                 placeholder="연락처">
                     </div>
                     <div class="update-value category">
-                        <input type="hidden" name="status" id="category">
+                        <input type="hidden" name="status" id="status">
                         <div class="category-select">
                             <i class="fa-solid fa-info-circle"></i>
                             <span class="category-selected">

--- a/clean4u/src/main/resources/templates/supplyItem/list-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItem/list-form.mustache
@@ -23,7 +23,7 @@
                     <input class="search-input" type="text" placeholder="검색어를 입력해주세요." value="{{name}}" name="name">
                 </div>
                 <div class="update-value category">
-                    <input type="hidden" name="lowStock" id="category" {{#lowStock}}value="{{lowStock}}" {{/lowStock}}>
+                    <input type="hidden" name="lowStock" id="lowStock" {{#lowStock}}value="{{lowStock}}" {{/lowStock}}>
                     <div class="category-select" {{#lowStock}}data-selected="{{lowStock}}" {{/lowStock}}>
                         <i class="fa-solid fa-list"></i>
                         <span class="category-selected">

--- a/clean4u/src/main/resources/templates/supplyItemHistory/list-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItemHistory/list-form.mustache
@@ -19,7 +19,7 @@
             </div>
             <form class="search-wrapper history-input" method="get" action="/supply-item-history/list">
                 <div class="update-value category">
-                    <input type="hidden" name="type" id="category" value="{{#type}}{{type}}{{/type}}">
+                    <input type="hidden" name="type" id="type" value="{{#type}}{{type}}{{/type}}">
                     <div class="category-select" {{#type}}data-selected="{{type}}"{{/type}}>
                         <i class="fa-solid fa-list"></i>
                         <span class="category-selected">

--- a/clean4u/src/main/resources/templates/supplyItemHistory/save-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItemHistory/save-form.mustache
@@ -17,7 +17,7 @@
                             거래 유형
                         </label>
                         <div class="update-value category">
-                            <input type="hidden" name="type" id="category">
+                            <input type="hidden" name="type" id="type">
                             <div class="category-select">
                                 <span class="category-selected">거래 유형 선택</span>
                                 <i class="fa-solid fa-chevron-down"></i>


### PR DESCRIPTION
## 변경 배경
카테고리 드롭다운의 ID 중복 이슈를 수정합니다.

## 주요 변경 사항
- 카테고리 드롭다운 ID 중복 이슈 수정(FE)

## 기술 스택 및 구현 방식
- FE 작업
- Mustache, JavaScript
- HTML ID 속성 중복 제거

## 영향 범위
- [x] Frontend
- [ ] Backend
- [ ] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 드롭다운 정상 동작 확인

### 테스트 방법
1. 카테고리 드롭다운 ID 확인
2. 드롭다운 동작 확인
3. 중복 ID 제거 확인

## 관련 이슈
- 이슈 번호: #338
- Closes #338