### PR TITLE
BE: BaseTime 상속 제거 및 필드 방식으로 전환(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItem.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItem.java
@@ -4,13 +4,16 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.example.clean4u.time.BaseTimeEntity;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.sql.Timestamp;
 
 @NoArgsConstructor
 @Data
 @Entity
 @Table(name = "laundry_item_tb")
-public class LaundryItem extends BaseTimeEntity {
+public class LaundryItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "laundry_item_id")
@@ -28,6 +31,14 @@ public class LaundryItem extends BaseTimeEntity {
 
     @Column(name = "description")
     private String description;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Timestamp createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
 
     @Builder
     public LaundryItem(String name, LaundryCategory category, Integer basePrice, String description) {

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOption.java
@@ -4,13 +4,16 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.example.clean4u.time.BaseTimeEntity;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.sql.Timestamp;
 
 @NoArgsConstructor
 @Data
 @Entity
 @Table(name = "laundry_option_tb")
-public class LaundryOption extends BaseTimeEntity {
+public class LaundryOption {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "laundry_option_id")
@@ -27,6 +30,14 @@ public class LaundryOption extends BaseTimeEntity {
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Timestamp createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
 
     @Builder
     public LaundryOption(String name, Integer extraPrice, String description, Boolean isActive) {

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItem.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItem.java
@@ -4,13 +4,16 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.example.clean4u.time.BaseTimeEntity;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.sql.Timestamp;
 
 @NoArgsConstructor
 @Data
 @Entity
 @Table(name = "supply_item_tb")
-public class SupplyItem extends BaseTimeEntity {
+public class SupplyItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "supply_item_id")
@@ -30,6 +33,14 @@ public class SupplyItem extends BaseTimeEntity {
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Timestamp createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
 
     @Builder
     public SupplyItem(String name, String unit, Integer stockQuantity, Integer safetyStock, Boolean isActive) {

--- a/clean4u/src/main/java/org/example/clean4u/supplyItemHistory/SupplyItemHistory.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItemHistory/SupplyItemHistory.java
@@ -6,13 +6,16 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.example.clean4u.employee.Employee;
 import org.example.clean4u.supplyItem.SupplyItem;
-import org.example.clean4u.time.BaseTimeEntity;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.sql.Timestamp;
 
 @NoArgsConstructor
 @Data
 @Entity
 @Table(name = "supply_item_history_tb")
-public class SupplyItemHistory extends BaseTimeEntity {
+public class SupplyItemHistory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "supply_item_history_id")
@@ -41,6 +44,14 @@ public class SupplyItemHistory extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "employee_id", nullable = false)
     private Employee employee;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Timestamp createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
 
     @Builder
     public SupplyItemHistory(SupplyItem supplyItem, Type type, Integer quantity, Integer stockBefore, Integer stockAfter, String memo, Employee employee) {


### PR DESCRIPTION
## 변경 배경
BaseTime 상속을 제거하고 필드 방식으로 전환합니다.

## 주요 변경 사항
- LaundryItem BaseTime 상속 제거 및 필드로 전환(BE)
- LaundryOption BaseTime 상속 제거 및 필드로 전환(BE)
- SupplyItem BaseTime 상속 제거 및 필드로 전환(BE)
- SupplyItemHistory BaseTime 상속 제거 및 필드로 전환(BE)

## 기술 스택 및 구현 방식
- BE 작업
- Spring Boot, JPA
- Entity 구조 변경 (상속 → 필드)

## 영향 범위
- [ ] Frontend
- [x] Backend
- [x] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 기존 기능 정상 동작 확인

### 테스트 방법
1. 각 Entity의 필드 구조 확인
2. 생성/수정일 정보 확인
3. 관련 기능 동작 확인

## 관련 이슈
- 이슈 번호: #349
- Closes #349