### PR TITLE
fix: 페이징 URL 쿼리스트링 공백(%20) 제거(BE, FE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryItem/LaundryItemController.java
@@ -34,7 +34,7 @@ public class LaundryItemController {
         String queryString = request.getQueryString();
 
         if (queryString != null) {
-            queryString = queryString.replaceAll("(&page=\\d+)", "");
+            queryString = queryString.replaceAll("(page=\\d+)", "");
             queryString = queryString.replaceAll("(&size=\\d+)", "");
             if (!queryString.isBlank()) {
                 queryString = "&" + queryString;

--- a/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionController.java
+++ b/clean4u/src/main/java/org/example/clean4u/laundryOption/LaundryOptionController.java
@@ -36,7 +36,7 @@ public class LaundryOptionController {
         String queryString = request.getQueryString();
 
         if (queryString != null) {
-            queryString = queryString.replaceAll("(&page=\\d+)", "");
+            queryString = queryString.replaceAll("(page=\\d+)", "");
             queryString = queryString.replaceAll("(&size=\\d+)", "");
             if (!queryString.isBlank()) {
                 queryString = "&" + queryString;

--- a/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItem/SupplyItemController.java
@@ -34,7 +34,7 @@ public class SupplyItemController {
         String queryString = request.getQueryString();
 
         if (queryString != null) {
-            queryString = queryString.replaceAll("(&page=\\d+)", "");
+            queryString = queryString.replaceAll("(page=\\d+)", "");
             queryString = queryString.replaceAll("(&size=\\d+)", "");
             if (!queryString.isBlank()) {
                 queryString = "&" + queryString;

--- a/clean4u/src/main/java/org/example/clean4u/supplyItemHistory/SupplyItemHistoryController.java
+++ b/clean4u/src/main/java/org/example/clean4u/supplyItemHistory/SupplyItemHistoryController.java
@@ -43,7 +43,7 @@ public class SupplyItemHistoryController {
         String queryString = request.getQueryString();
 
         if (queryString != null) {
-            queryString = queryString.replaceAll("(&page=\\d+)", "");
+            queryString = queryString.replaceAll("(page=\\d+)", "");
             queryString = queryString.replaceAll("(&size=\\d+)", "");
             if (!queryString.isBlank()) {
                 queryString = "&" + queryString;

--- a/clean4u/src/main/resources/templates/laundryItem/list-form.mustache
+++ b/clean4u/src/main/resources/templates/laundryItem/list-form.mustache
@@ -75,10 +75,7 @@
 <ul class="pagination">
     {{#laundryItemPage.previousPageNumber}}
         <li class="page-btn">
-            <a href="/laundry-item/list?page={{laundryItemPage.previousPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}
-            ">
-            <i class="fa-solid fa-chevron-right"></i>
-            </a>
+            <a href="/laundry-item/list?page={{laundryItemPage.previousPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}"><i class="fa-solid fa-chevron-left"></i></a>
         </li>
     {{/laundryItemPage.previousPageNumber}}
     {{^laundryItemPage.previousPageNumber}}
@@ -89,17 +86,13 @@
 
     {{#laundryItemPage.pageLinks}}
         <li class="page-btn {{#active}}active{{/active}}">
-            <a href="/laundry-item/list?page={{displayNumber}}
-            &size={{laundryItemPage.size}}{{#queryString}}{{queryString}}{{/queryString}}">{{displayNumber}}</a>
+            <a href="/laundry-item/list?page={{displayNumber}}&size={{laundryItemPage.size}}{{#queryString}}{{queryString}}{{/queryString}}">{{displayNumber}}</a>
         </li>
     {{/laundryItemPage.pageLinks}}
 
     {{#laundryItemPage.nextPageNumber}}
         <li class="page-btn">
-            <a href="/laundry-item/list?page={{laundryItemPage.nextPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}
-            ">
-            <i class="fa-solid fa-chevron-right"></i>
-            </a>
+            <a href="/laundry-item/list?page={{laundryItemPage.nextPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}"><i class="fa-solid fa-chevron-right"></i></a>
         </li>
     {{/laundryItemPage.nextPageNumber}}
     {{^laundryItemPage.nextPageNumber}}

--- a/clean4u/src/main/resources/templates/supplyItemHistory/list-form.mustache
+++ b/clean4u/src/main/resources/templates/supplyItemHistory/list-form.mustache
@@ -95,8 +95,7 @@
 <ul class="pagination">
     {{#supplyItemHistoryPage.previousPageNumber}}
         <li class="page-btn">
-            <a href="/supply-item-history/list?page={{supplyItemHistoryPage.previousPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}
-            ">
+            <a href="/supply-item-history/list?page={{supplyItemHistoryPage.previousPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}">
             <i class="fa-solid fa-chevron-left"></i>
             </a>
         </li>
@@ -109,15 +108,13 @@
 
     {{#supplyItemHistoryPage.pageLinks}}
         <li class="page-btn {{#active}}active{{/active}}">
-            <a href="/supply-item-history/list?page={{displayNumber}}
-            &size={{supplyItemHistoryPage.size}}{{#queryString}}{{queryString}}{{/queryString}}">{{displayNumber}}</a>
+            <a href="/supply-item-history/list?page={{displayNumber}}&size={{supplyItemHistoryPage.size}}{{#queryString}}{{queryString}}{{/queryString}}">{{displayNumber}}</a>
         </li>
     {{/supplyItemHistoryPage.pageLinks}}
 
     {{#supplyItemHistoryPage.nextPageNumber}}
         <li class="page-btn">
-            <a href="/supply-item-history/list?page={{supplyItemHistoryPage.nextPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}
-            ">
+            <a href="/supply-item-history/list?page={{supplyItemHistoryPage.nextPageNumber}}{{#queryString}}{{queryString}}{{/queryString}}">
             <i class="fa-solid fa-chevron-right"></i>
             </a>
         </li>


### PR DESCRIPTION
## 변경 배경
페이징 URL 쿼리스트링의 공백(%20)을 제거합니다.

## 주요 변경 사항
- 페이징 URL 쿼리스트링 공백(%20) 제거(BE)
- 페이징 URL page 파라미터 정규화(BE)
- 페이징 a태그 공백 제거(FE)

## 기술 스택 및 구현 방식
- FE, BE 작업
- Spring Boot, Mustache
- URL 정규화 처리

## 영향 범위
- [x] Frontend
- [x] Backend
- [ ] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] URL 정규화 확인

### 테스트 방법
1. 페이징 URL 확인
2. 공백 제거 확인
3. URL 정규화 확인

## 관련 이슈
- 이슈 번호: #388
- Closes #388