### PR TITLE
fix: OrderStatusHistory 조회 쿼리 메서드 복구(BE)

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/orderStatusHistory/OrderStatusHistoryRepository.java
+++ b/clean4u/src/main/java/org/example/clean4u/orderStatusHistory/OrderStatusHistoryRepository.java
@@ -21,6 +21,9 @@ public interface OrderStatusHistoryRepository extends OrderStatusHistoryReposito
 
     List<OrderStatusHistory> findByOrderId(@Param("orderId") Long orderId);
 
+    @Query("SELECT sh FROM OrderStatusHistory sh WHERE sh.order.id = :orderId ORDER BY sh.createdAt ASC")
+    List<OrderStatusHistory> findByOrderIdOrderByCreatedAtAsc(@Param("orderId") Long orderId);
+
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM OrderStatusHistory sh WHERE sh.order.id = :orderId")
     void deleteByOrderId(@Param("orderId") Long orderId);


### PR DESCRIPTION
## 변경 배경
OrderStatusHistory 조회 Repository 메서드를 복구합니다.

## 주요 변경 사항
- OrderStatusHistory 조회 Repository 메서드 복구(BE)

## 기술 스택 및 구현 방식
- BE 작업
- Spring Boot, Spring Data JPA
- Repository 메서드 복구

## 영향 범위
- [ ] Frontend
- [x] Backend
- [x] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 메서드 정상 동작 확인

### 테스트 방법
1. OrderStatusHistory 조회 메서드 확인
2. 메서드 동작 확인
3. 쿼리 결과 확인

## 관련 이슈
- 이슈 번호: #555
- Closes #555