### PR TITLE
fix: 수정 페이지 URL 파싱 공통 오류 수정(FE)

### DIFF
--- a/clean4u/src/main/resources/static/js/laundryItem/update.js
+++ b/clean4u/src/main/resources/static/js/laundryItem/update.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", () => {
         form.addEventListener("submit", async (e) => {
             e.preventDefault();
             const formData = new FormData(form);
-            const id = window.location.pathname.match(/\/(\d+)\/update/)[1];
+            const id = window.location.pathname.match(/\/(\d+)\/edit/)[1];
             const data = {
                 name: formData.get("name"),
                 category: formData.get("category"),

--- a/clean4u/src/main/resources/static/js/laundryOption/update.js
+++ b/clean4u/src/main/resources/static/js/laundryOption/update.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", () => {
         form.addEventListener("submit", async (e) => {
             e.preventDefault();
             const formData = new FormData(form);
-            const id = window.location.pathname.match(/\/(\d+)\/update/)[1];
+            const id = window.location.pathname.match(/\/(\d+)\/edit/)[1];
             const data = {
                 name: formData.get("name"),
                 extraPrice: parseInt(formData.get("extraPrice")) || 0,

--- a/clean4u/src/main/resources/static/js/supplyItem/update.js
+++ b/clean4u/src/main/resources/static/js/supplyItem/update.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded", () => {
         form.addEventListener("submit", async (e) => {
             e.preventDefault();
             const formData = new FormData(form);
-            const id = window.location.pathname.match(/\/(\d+)\/update/)[1];
+            const id = window.location.pathname.match(/\/(\d+)\/edit/)[1];
             
             const data = {
                 name: formData.get("name"),


### PR DESCRIPTION
## 변경 배경
수정 페이지에서 발생하는 JavaScript 오류를 수정하기 위해 이 PR을 제출합니다.
SupplyItem, LaundryItem, LaundryOption 수정 페이지에서 수정 버튼을 클릭할 때 URL 경로 파싱 오류로 인해 `Cannot read properties of null (reading '1')` 에러가 발생했습니다.
기존에 사용하던 정규표현식 패턴 `/\/(\d+)\/update/`가 실제 URL 경로인 `/edit`와 일치하지 않아 `match()` 메서드가 null을 반환하고, 이로 인해 `match[1]`에 접근할 때 오류가 발생했습니다.
이 문제를 해결하기 위해 모든 수정 페이지의 JavaScript 파일에서 URL 패턴을 실제 경로에 맞게 수정했습니다.

## 주요 변경 사항
- SupplyItem 수정 페이지 URL 패턴 수정: `/\/(\d+)\/update/` → `/\/(\d+)\/edit/` (FE)
- LaundryItem 수정 페이지 URL 패턴 수정: `/\/(\d+)\/update/` → `/\/(\d+)\/edit/` (FE)
- LaundryOption 수정 페이지 URL 패턴 수정: `/\/(\d+)\/update/` → `/\/(\d+)\/edit/` (FE)

## 기술 스택 및 구현 방식
- FE 작업: JavaScript 정규표현식을 활용한 URL 경로 파싱, `window.location.pathname.match()` 메서드를 사용하여 ID 추출, 기존 코드 구조 유지하며 최소한의 변경으로 문제 해결

## 영향 범위
- [x] Frontend
- [ ] Backend
- [ ] Database
- [ ] API
- [ ] 공통 모듈

## 테스트
- [x] 로컬 테스트 완료
- [x] 수정 버튼 클릭 시 오류 없이 정상 동작 확인
- [x] URL 패턴 매칭 정상 작동 확인

### 테스트 방법
1. SupplyItem 수정 페이지 테스트
   - `/supply-items/{id}/edit` 경로에서 수정 버튼 클릭
   - JavaScript 콘솔에 오류가 없는지 확인
   - 수정 요청이 정상적으로 전송되는지 확인
   - 수정 완료 후 상세 페이지로 정상 리다이렉트되는지 확인

2. LaundryItem 수정 페이지 테스트
   - `/laundry-items/{id}/edit` 경로에서 수정 버튼 클릭
   - JavaScript 콘솔에 오류가 없는지 확인
   - 수정 요청이 정상적으로 전송되는지 확인
   - 수정 완료 후 상세 페이지로 정상 리다이렉트되는지 확인

3. LaundryOption 수정 페이지 테스트
   - `/laundry-options/{id}/edit` 경로에서 수정 버튼 클릭
   - JavaScript 콘솔에 오류가 없는지 확인
   - 수정 요청이 정상적으로 전송되는지 확인
   - 수정 완료 후 상세 페이지로 정상 리다이렉트되는지 확인

## 관련 이슈
- 이슈 번호: #614 
- Closes #614 