### PR TITLE
feat: 공지사항 파일 구현 수정

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/notice/Notice.java
+++ b/clean4u/src/main/java/org/example/clean4u/notice/Notice.java
@@ -55,20 +55,26 @@ public class Notice {
     }
 
     public void addNoticeFile(NoticeFile noticeFile) {
+        if (noticeFile == null) return;
+
         this.noticeFiles.add(noticeFile);
         noticeFile.setNotice(this);
     }
 
     public void addNoticeFiles(List<NoticeFile> files) {
-        if (files != null && !files.isEmpty()) { return; }
-
-        for (NoticeFile file : files) {
-            this.noticeFiles.addAll(files);
+        if (files == null || files.isEmpty()) { return; }
+        for (NoticeFile file: files) {
+            addNoticeFile(file);
         }
     }
 
     public void clearFiles() {
         this.noticeFiles.clear();
+    }
+
+    public void removeFiles(List<NoticeFile> files) {
+        if (files == null || files.isEmpty()) return;
+        this.noticeFiles.removeAll(files);
     }
 
 }

--- a/clean4u/src/main/java/org/example/clean4u/notice/NoticeController.java
+++ b/clean4u/src/main/java/org/example/clean4u/notice/NoticeController.java
@@ -87,14 +87,4 @@ public class NoticeController {
 
         return "/notice/update-form";
     }
-
-//    @PostMapping("/notices/{noticeId}/image")
-//    public String updateNoticeImages(@PathVariable Long noticeId,
-//                                     @ModelAttribute @Valid NoticeRequest.ImageUploadDTO dto,
-//                                     HttpSession session) {
-//        Employee sessionUser = (Employee) session.getAttribute("sessionUser");
-//        noticeService.updateNoticeImages(noticeId, dto, sessionUser);
-//
-//        return "redirect:/notices/" + noticeId;
-//    }
 }

--- a/clean4u/src/main/java/org/example/clean4u/notice/NoticeRequest.java
+++ b/clean4u/src/main/java/org/example/clean4u/notice/NoticeRequest.java
@@ -41,11 +41,5 @@ public class NoticeRequest {
         private String content;
         private List<Long> deleteFileIds = new ArrayList<>();
         private List<MultipartFile> newAttachments = new ArrayList<>();
-
-    }
-
-    @Data
-    public static class ImageUploadDTO {
-        List<MultipartFile> uploadImages;
     }
 }

--- a/clean4u/src/main/java/org/example/clean4u/notice/NoticeService.java
+++ b/clean4u/src/main/java/org/example/clean4u/notice/NoticeService.java
@@ -134,6 +134,13 @@ public class NoticeService {
         }
         notice.update(dto); // 제목, 내용만
 
+        if (!dto.getDeleteFileIds().isEmpty()) {
+            List<NoticeFile> deleteTargets = noticeFileRepository.findAllById(dto.getDeleteFileIds());
+
+            deleteFiles(deleteTargets);
+            notice.removeFiles(deleteTargets);
+        }
+
         updateNoticeFiles(notice.getId(), dto, sessionUser);
         return new NoticeResponse.DetailDTO(notice);
     }

--- a/clean4u/src/main/resources/static/css/notice.css
+++ b/clean4u/src/main/resources/static/css/notice.css
@@ -321,10 +321,13 @@
 }
 
 .detail-value-file {
+    display: flex;
+    flex-direction: column;
     color: var(--color-dark-blue);
     font-weight: 600;
     font-size: 1.1rem;
     flex: 1;
+    gap: 0.5rem;
 }
 
 .body-upper-side {
@@ -510,8 +513,32 @@
 
 /* 파일 */
 .file-list {
-    width: 100%;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    flex: 1;
+}
+
+.file-item {
+    display: flex;
+    align-items: center;
+}
+
+.image-label-file {
+    background-color: var(--color-cream);
+    font-size: 0.9rem;
+    font-weight: 500;
+    border: 1px solid var(--color-light-gray);
+    border-radius: 10px;
+    color: var(--color-gray);
+    width: 100%;
+    white-space: nowrap;
+    padding: 0.5rem 0.7rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.remove-file {
+    cursor: pointer;
 }

--- a/clean4u/src/main/resources/static/js/notice/notice-file.js
+++ b/clean4u/src/main/resources/static/js/notice/notice-file.js
@@ -1,19 +1,50 @@
 const fileInput = document.getElementById("attachments");
-const fileNameSpan = document.getElementById("fileName");
+const noFile = document.getElementById("noFile"); // 첨부파일 없음
+const newFile = document.getElementById("newFile"); // 새파일
 
 fileInput.addEventListener("change", function () {
     const files = fileInput.files;
+    newFile.innerHTML = "";
 
     if (!files || files.length === 0) {
-        fileNameSpan.textContent = "선택된 파일 없음";
+        checkEmpty();
         return;
     }
 
-    fileNameSpan.innerHTML = "";
+    if (noFile) noFile.style.display = "none";
 
     Array.from(files).forEach(file => {
         const div = document.createElement("div");
-        div.textContent = file.name;
-        fileNameSpan.appendChild(div);
-    })
-})
+        div.classList.add("image-label-file", "new-file-label")
+        div.style.marginBottom = "8px";
+        div.style.color = "blue";
+        div.innerHTML = `${file.name}<i class="fa-solid fa-x remove-file" style=""></i>`;
+        newFile.appendChild(div);
+    });
+});
+
+document.addEventListener("click", (e) => {
+    if (!e.target.classList.contains("remove-file")) return;
+
+    const target = e.target.closest(".image-label-file");
+    const fileId = target.dataset.fileId;
+
+    if (fileId) {
+        const hiddenInput = document.getElementById("deleteFileIds");
+        const deleteIds = hiddenInput.value ? hiddenInput.value.split(",") : [];
+        deleteIds.push(fileId);
+        hiddenInput.value = deleteIds.join(",");
+    }
+
+    target.remove();
+    checkEmpty();
+});
+
+function checkEmpty() {
+    const totalFiles = document.querySelectorAll(".image-label-file").length;
+    if (totalFiles === 0) {
+        if (noFile) noFile.style.display = "block";
+    } else {
+        if (noFile) noFile.style.display = "none";
+    }
+}

--- a/clean4u/src/main/resources/static/js/notice/save.js
+++ b/clean4u/src/main/resources/static/js/notice/save.js
@@ -1,0 +1,36 @@
+const input = document.getElementById("attachments");
+const fileList = document.getElementById("attachment-list");
+
+input.addEventListener("change", () => {
+    fileList.innerHTML = "";
+
+    if (input.files.length === 0) {
+        addNoFileMessage();
+        return;
+    }
+
+    const files = input.files;
+
+    Array.from(files).forEach((file, idx) => {
+        const span = document.createElement("span");
+        span.className = "image-label-file";
+        span.innerHTML = `<span>${file.name}</span><i class="fa-solid fa-x remove-file" data-index="${idx}"></i>`;
+        fileList.appendChild(span);
+    });
+});
+
+document.addEventListener("click", (e) => {
+    if (!e.target.classList.contains("remove-file")) return;
+
+    const span = e.target.closest(".image-label-file");
+    span.remove();
+
+    const remainingFiles = fileList.querySelectorAll(".image-label-file").length;
+    if (remainingFiles === 0) {
+        addNoFileMessage();
+    }
+});
+
+function addNoFileMessage() {
+    fileList.innerHTML = `<span id="noFile" class="image-label"> 선택된 파일 없음 </span>`;
+}

--- a/clean4u/src/main/resources/static/js/notice/update.js
+++ b/clean4u/src/main/resources/static/js/notice/update.js
@@ -4,43 +4,35 @@ document.addEventListener("DOMContentLoaded", () => {
 
     form.addEventListener("submit", async (e) => {
         e.preventDefault();
-        const files = form.uploadImages?.files;
-        const hasFiles = files && files.length > 0;
         const noticeId = window.location.pathname.match(/\/(\d+)\/edit/)[1];
+        const formData = new FormData();
+
+        formData.append("title", form.title.value);
+        formData.append("content", $('#summernote').summernote('code'));
+
+        const deleteInput = document.getElementById("deleteFileIds");
+        if (deleteInput && deleteInput.value) {
+            deleteInput.value.split(",").forEach(id => {
+                formData.append("deleteFileIds", id);
+            });
+        }
+
+        const files = document.getElementById("attachments").files;
+        if (files && files.length > 0) {
+            Array.from(files).forEach(file => {
+                formData.append("newAttachments", file);
+            });
+        }
 
         try {
-            const textFormData = new FormData();
-            textFormData.append("title", form.title.value);
-            textFormData.append("content", $('#summernote').summernote('code'));
-
-            const textRes = await fetch(`/api/v1/notices/${noticeId}`, {
+            const res = await fetch(`/api/v1/notices/${noticeId}`, {
                 method: "PUT",
-                body: textFormData
+                body: formData
             });
 
-            if (!textRes.ok) {
-                const errorBody = await textRes.json();
+            if (!res.ok) {
+                const errorBody = await res.json();
                 throw new Error(errorBody.message);
-            }
-            if (textRes.ok) {
-                console.log(textRes);
-            }
-
-            if (hasFiles) {
-                const imageFormData = new FormData();
-                Array.from(files).forEach(file => {
-                    imageFormData.append("uploadImages", file);
-                });
-
-                const imgRes = await fetch(`/notices/${noticeId}/image`, {
-                    method: "POST",
-                    body: imageFormData,
-                });
-
-                if (!imgRes.ok) {
-                    const errorBody = await imgRes.json();
-                    throw new Error(errorBody.message);
-                }
             }
 
             window.location.href = `/notices/${noticeId}`;

--- a/clean4u/src/main/resources/templates/notice/detail-form.mustache
+++ b/clean4u/src/main/resources/templates/notice/detail-form.mustache
@@ -55,16 +55,16 @@
                         <i class="fa-solid fa-file"></i>
                         첨부 파일
                     </span>
-                    {{#notice.attachments}}
                     <div class="detail-value-file">
+                        {{#notice.attachments}}
                         <div class="file-item image-label">
                             <i class="fa-solid fa-paperclip"></i>
-                            <a href="/api/v1/files/{{fileId}}" class="file-link">
+                            <a href="/api/v1/files/{{fileId}}">
                                 {{originalName}}
                             </a>
                         </div>
+                        {{/notice.attachments}}
                     </div>
-                    {{/notice.attachments}}
                     {{^notice.attachments}}
                     <span id="fileName" class="image-label"> 첨부파일 없음</span>
                     {{/notice.attachments}}

--- a/clean4u/src/main/resources/templates/notice/save-form.mustache
+++ b/clean4u/src/main/resources/templates/notice/save-form.mustache
@@ -33,7 +33,9 @@
                             </label>
                         </div>
                         <input type="file" id="attachments" name="attachments" hidden multiple>
-                        <span id="fileName" class="image-label"> 선택된 파일 없음</span>
+                        <div class="file-list" id="attachment-list">
+                            <span id="noFile" class="image-label"> 선택된 파일 없음 </span>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -48,4 +50,4 @@
 {{> layout/footer}}
 
 <script src="/js/notice/notice-summernote.js"></script>
-<script src="/js/notice/notice-file.js"></script>
+<script src="/js/notice/save.js"></script>

--- a/clean4u/src/main/resources/templates/notice/update-form.mustache
+++ b/clean4u/src/main/resources/templates/notice/update-form.mustache
@@ -4,7 +4,7 @@
 
 <div class="notice-container">
     <div class="notice-container-content">
-        <form id="updateForm">
+        <form id="updateForm" enctype="multipart/form-data">
             <div class="notice-header">
                 <label class="notice-label">
                     <i class="fa-solid fa-bullhorn"></i>제목:
@@ -33,15 +33,20 @@
                                 </span>
                             </label>
                         </div>
-                        <input type="file" id="attachments" name="attachments" hidden multiple>
-                            <div class="file-list">
+                        <input type="file" id="attachments" name="newAttachments" hidden multiple>
+                            <div class="file-list" id="fileList">
+                                <input type="hidden" name="deleteFileIds" id="deleteFileIds">
                             {{#notice.attachments}}
-                                <span id="fileName" class="image-label">{{originalName}}</span>
+                                <span class="image-label-file" data-file-id="{{fileId}}">{{originalName}}
+                                    <i class="fa-solid fa-x remove-file"></i>
+                                </span>
                             {{/notice.attachments}}
+                                <span id="newFile"></span>
+                                <span id="noFile" class="image-label"
+                                      style="{{#notice.attachments}}display:none;{{/notice.attachments}}
+                                              {{^notice.attachments}}display:block;{{/notice.attachments}}"
+                                > 첨부파일 없음 </span>
                             </div>
-                        {{^notice.attachments}}
-                            <span id="fileName" class="image-label"> 첨부파일 없음</span>
-                        {{/notice.attachments}}
                     </div>
                 </div>
             </div>
@@ -56,5 +61,5 @@
 {{> layout/footer}}
 
 <script src="/js/notice/update.js"></script>
-<script src="/js/notice/notice-summernote.js"></script>
 <script src="/js/notice/notice-file.js"></script>
+<script src="/js/notice/notice-summernote.js"></script>


### PR DESCRIPTION
### 변경사항

- 공지사항 수정 시 기존 첨부파일의 선택적 삭제 및 신규 파일 다중 추가 기능 구현
- 파일 목록 상태(기존/신규/삭제 예정)에 따른 동적 UI 가시성 개선 및 실시간 피드백 반영
- 백엔드 도메인 모델 내 파일 관리 로직 최적화 및 물리 파일 삭제 연동

### 수정내용
1. 백엔드 (Java/Spring)
- Domain Model (Notice.java):
removeFiles(List<NoticeFile> files) 메서드를 추가하여 엔티티 내부 컬렉션에서 파일을 안전하게 제거하도록 구현했습니다.

  중복 로직을 제거하고 addNoticeFiles 메서드의 방어 코드(null/empty 체크)를 강화했습니다.

- Service (NoticeService.java):
 updateNotice 시 deleteFileIds를 전달받아 실제 DB 레코드와 저장소의 물리 파일을 동시 삭제하는 deleteFiles 연동 로직을 추가했습니다.

2. 프론트엔드 (JavaScript/Mustache)
- 파일 리스트 동적 제어 (notice-file.js, save.js):
  실시간 개수 체크: querySelectorAll을 활용해 화면에 남은 파일 상자(.image-label-file)의 개수를 정확히 파악하여 "첨부파일 없음" 메시지를 유동적으로 노출합니다.

  신규 파일 미리보기: 파일 선택 시 기존 목록을 유지하며 새 파일명을 리스트에 추가하고, 각각 개별 삭제용 X 아이콘을 생성합니다.

- 데이터 전송 로직 (update.js):
FormData를 사용하여 수정한 제목, 내용과 함께 삭제 대상 ID(deleteFileIds) 및 신규 첨부파일(newAttachments)을 멀티파트 형식으로 서버에 전송합니다.

- UI/UX 개선 (update-form.mustache):
파일이 하나도 없을 때만 "첨부파일 없음" 상자가 보이도록 CSS 스타일(display) 제어 로직을 강화했습니다.
