### PR TITLE
feat: NoticeFileService 생성

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/notice/NoticeFile.java
+++ b/clean4u/src/main/java/org/example/clean4u/notice/NoticeFile.java
@@ -5,7 +5,10 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Timestamp;
 
 @Entity
@@ -52,6 +55,18 @@ public class NoticeFile {
         this.fileSize = fileSize;
         this.filePath = filePath;
         this.createdAt = createdAt;
+    }
+
+    public static NoticeFile createNoticeFile(MultipartFile file, String storedName, String filePath) {
+        Path fullPath = Paths.get(filePath).resolve(storedName);
+
+        return NoticeFile.builder()
+                .originalName(file.getOriginalFilename())
+                .storedName(storedName)
+                .contentType(file.getContentType())
+                .fileSize(file.getSize())
+                .filePath(fullPath.toString())
+                .build();
     }
 }
 

--- a/clean4u/src/main/java/org/example/clean4u/notice/NoticeFileApiController.java
+++ b/clean4u/src/main/java/org/example/clean4u/notice/NoticeFileApiController.java
@@ -17,18 +17,18 @@ import java.nio.file.Path;
 @RequestMapping
 public class NoticeFileApiController {
 
-    private final NoticeService noticeService;
+    private final NoticeFileService noticeFileService;
 
     @GetMapping("/api/v1/files/{fileId}")
     public ResponseEntity<Resource> download(@PathVariable Long fileId) {
-        NoticeFile file = noticeService.getFileInfo(fileId); // 파일 조회
+        NoticeFile file = noticeFileService.getFileInfo(fileId); // 파일 조회
 
-        Path path = noticeService.getFile(file); // 파일 경로
+        Path path = noticeFileService.getFile(file); // 파일 경로
 
         Resource resource = new PathResource(path); // Resource 변환
 
         // 헤더 생성
-        HttpHeaders headers = noticeService.createDownloadHeaders(file, path);
+        HttpHeaders headers = noticeFileService.createDownloadHeaders(file, path);
 
         return ResponseEntity.ok()
                 .headers(headers)

--- a/clean4u/src/main/java/org/example/clean4u/notice/NoticeFileService.java
+++ b/clean4u/src/main/java/org/example/clean4u/notice/NoticeFileService.java
@@ -1,0 +1,108 @@
+package org.example.clean4u.notice;
+
+import lombok.RequiredArgsConstructor;
+import org.example.clean4u._core.errors.exception.Exception400;
+import org.example.clean4u._core.errors.exception.Exception404;
+import org.example.clean4u._core.errors.exception.Exception500;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeFileService {
+    private final NoticeFileRepository noticeFileRepository;
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
+            "jpg", "jpeg", "png", "gif", "pdf", "txt", "zip"
+    );
+
+    // 단일 파일 최대 크기 (10MB)
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024L;
+
+    public void validateFiles (List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+
+        for (MultipartFile file : files) {
+
+            if (file == null || file.isEmpty()) {
+                throw new Exception400("업로드할 파일이 없습니다");
+            }
+
+            if (file.getSize() > MAX_FILE_SIZE) {
+                throw new Exception400("최대 용량을 초과하였습니다, 최대 10MB까지 업로드 가능합니다");
+            }
+
+            String originalName = file.getOriginalFilename();
+            if (originalName == null || !originalName.contains(".")) {
+                throw new Exception400("확장자가 없는 파일입니다");
+            }
+
+            String extension = originalName.substring(originalName.lastIndexOf(".") + 1).toLowerCase();
+
+            if (!ALLOWED_EXTENSIONS.contains(extension)) {
+                throw new Exception400("허용되지 않는 파일 형식입니다" + extension);
+            }
+        }
+    }
+
+    public NoticeFile getFileInfo(Long fileId) {
+        NoticeFile info = noticeFileRepository.findById(fileId)
+                .orElseThrow(() -> new Exception404("해당 파일이 없습니다"));
+
+        return info;
+    }
+
+    public Path getFile(NoticeFile file) {
+        String filePath = file.getFilePath();
+        if (filePath == null || filePath.isEmpty()) {
+            throw new Exception500("파일 경로가 없습니다");
+        }
+
+        Path path = Paths.get(filePath);
+
+        if (!Files.exists(path) || !Files.isReadable(path)) {
+            throw new Exception500("서버 내부 오류가 발생했습니다");
+        }
+
+        return path;
+    }
+
+    public HttpHeaders createDownloadHeaders(NoticeFile file, Path path) {
+        HttpHeaders headers = new HttpHeaders();
+
+        String contentType = file.getContentType();
+        if (contentType == null) {
+            try {
+                contentType = Files.probeContentType(path);
+            } catch (Exception ignored) {}
+        }
+        headers.setContentType(MediaType.parseMediaType(
+                contentType != null ? contentType : "application/octet-stream"
+        ));
+
+        String encodedName = URLEncoder.encode(file.getOriginalName(), StandardCharsets.UTF_8)
+                .replace("+", "%20");
+
+        headers.add(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment; filename*=UTF-8''" + encodedName
+        );
+
+        headers.setContentLength(file.getFileSize());
+
+        return headers;
+    }
+}

--- a/clean4u/src/main/java/org/example/clean4u/notice/NoticeService.java
+++ b/clean4u/src/main/java/org/example/clean4u/notice/NoticeService.java
@@ -16,8 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,14 +24,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -46,15 +39,9 @@ public class NoticeService {
     @Value("${app.upload.notice-file-path}")
     private String noticeFilePath;
 
-    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
-            "jpg", "jpeg", "png", "gif", "pdf", "txt", "zip"
-    );
-
-    // 단일 파일 최대 크기 (10MB)
-    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024L;
-
     private final NoticeRepository noticeRepository;
     private final NoticeFileRepository noticeFileRepository;
+    private final NoticeFileService noticeFileService;
     private final FileUtil fileUtil;
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -63,31 +50,7 @@ public class NoticeService {
         Notice notice = dto.toEntity(sessionUser);
 
         List<MultipartFile> attachments = dto.getAttachments();
-        if (attachments != null || !attachments.isEmpty()) {
-
-            validateFiles(dto.getAttachments());
-
-            try {
-                for (MultipartFile file : attachments) {
-                    String originalName = file.getOriginalFilename();
-                    String storedName = fileUtil.saveFile(file, noticeFilePath);
-
-                    Path fullPath = Paths.get(noticeFilePath).resolve(storedName);
-
-                    NoticeFile noticeFile = NoticeFile.builder()
-                            .originalName(originalName)
-                            .storedName(storedName)
-                            .fileSize(file.getSize())
-                            .filePath(fullPath.toString())
-                            .build();
-
-
-                    notice.addNoticeFile(noticeFile);
-                }
-            } catch (IOException e) {
-                throw new Exception500("첨부파일 저장에 실패했습니다");
-            }
-        }
+        attachFiles(attachments, notice);
 
         noticeRepository.save(notice);
 
@@ -146,9 +109,7 @@ public class NoticeService {
     }
 
     @Transactional
-    public NoticeResponse.DetailDTO updateNoticeFiles(Long noticeId,
-                                                      @Valid NoticeRequest.UpdateDTO dto,
-                                                      Employee sessionUser) {
+    public void updateNoticeFiles(Long noticeId, @Valid NoticeRequest.UpdateDTO dto, Employee sessionUser) {
 
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new Exception404("해당 공지사항이 없습니다"));
@@ -161,32 +122,7 @@ public class NoticeService {
             notice.getNoticeFiles().removeIf(file -> dto.getDeleteFileIds().contains(file.getId()));
         }
 
-        if (dto.getNewAttachments() != null && !dto.getNewAttachments().isEmpty()) {
-            validateFiles(dto.getNewAttachments());
-
-            for (MultipartFile attachment : dto.getNewAttachments()) {
-                try {
-                    String originalName = attachment.getOriginalFilename();
-                    String storedName = fileUtil.saveFile(attachment, noticeFilePath);
-
-                    Path fullPath = Paths.get(noticeFilePath).resolve(storedName);
-
-                    NoticeFile noticeFile = NoticeFile.builder()
-                            .originalName(originalName)
-                            .storedName(storedName)
-                            .fileSize(attachment.getSize())
-                            .filePath(fullPath.toString())
-                            .build();
-
-                    notice.addNoticeFile(noticeFile);
-
-                } catch (IOException e) {
-                    throw new Exception500("첨부파일 저장에 실패했습니다");
-                }
-            }
-        }
-
-        return new NoticeResponse.DetailDTO(notice);
+        attachFiles(dto.getNewAttachments(), notice);
     }
 
     @Transactional
@@ -269,80 +205,21 @@ public class NoticeService {
         }
     }
 
-    // 파일
-    private void validateFiles (List<MultipartFile> files) {
-        if (files == null || files.isEmpty()) {
-            return;
-        }
+    private void attachFiles(List<MultipartFile> files, Notice notice) {
+        if (files == null || files.isEmpty()) return;
 
-        for (MultipartFile file : files) {
+        noticeFileService.validateFiles(files);
 
-            if (file == null || file.isEmpty()) {
-                throw new Exception400("업로드할 파일이 없습니다");
-            }
-
-            if (file.getSize() > MAX_FILE_SIZE) {
-                throw new Exception400("최대 용량을 초과하였습니다, 최대 10MB까지 업로드 가능합니다");
-            }
-
-            String originalName = file.getOriginalFilename();
-            if (originalName == null || !originalName.contains(".")) {
-                throw new Exception400("확장자가 없는 파일입니다");
-            }
-
-            String extension = originalName.substring(originalName.lastIndexOf(".") + 1).toLowerCase();
-
-            if (!ALLOWED_EXTENSIONS.contains(extension)) {
-                throw new Exception400("허용되지 않는 파일 형식입니다" + extension);
-            }
-        }
-    }
-
-    public NoticeFile getFileInfo(Long fileId) {
-        NoticeFile info = noticeFileRepository.findById(fileId)
-                .orElseThrow(() -> new Exception404("해당 파일이 없습니다"));
-
-        return info;
-    }
-
-    public Path getFile(NoticeFile file) {
-        String filePath = file.getFilePath();
-        if (filePath == null || filePath.isEmpty()) {
-            throw new Exception500("파일 경로가 없습니다");
-        }
-
-        Path path = Paths.get(filePath);
-
-        if (!Files.exists(path) || !Files.isReadable(path)) {
-            throw new Exception500("서버 내부 오류가 발생했습니다");
-        }
-
-        return path;
-    }
-
-    public HttpHeaders createDownloadHeaders(NoticeFile file, Path path) {
-        HttpHeaders headers = new HttpHeaders();
-
-        String contentType = file.getContentType();
-        if (contentType == null) {
+        for (MultipartFile file: files) {
             try {
-                contentType = Files.probeContentType(path);
-            } catch (Exception ignored) {}
+                String storedName = fileUtil.saveFile(file, noticeFilePath);
+
+                NoticeFile noticeFile = NoticeFile.createNoticeFile(file, storedName, noticeFilePath);
+                notice.addNoticeFile(noticeFile);
+            } catch (IOException e) {
+                throw new Exception500("첨부파일 저장에 실패했습니다");
+            }
         }
-        headers.setContentType(MediaType.parseMediaType(
-                contentType != null ? contentType : "application/octet-stream"
-        ));
-
-        String encodedName = URLEncoder.encode(file.getOriginalName(), StandardCharsets.UTF_8)
-                .replace("+", "%20");
-
-        headers.add(HttpHeaders.CONTENT_DISPOSITION,
-                "attachment; filename*=UTF-8''" + encodedName
-        );
-
-        headers.setContentLength(file.getFileSize());
-
-        return headers;
     }
 
 }


### PR DESCRIPTION
### 변경사항
- 관심사 분리(SoC)를 위한 리팩토링: NoticeService에 집중되어 있던 파일 관리 로직을 전담 서비스(NoticeFileService)로 추출
<br />

### 수정내용
- NoticeFileService 신규 생성:
  NoticeService에 있던 validateFiles, getFileInfo, getFile, createDownloadHeaders 등 파일 처리 핵심 로직 분리 이관함
- NoticeService 의존성 주입:
  NoticeFileService를 주입받아 파일 업로드 전 검증 로직 위임
  attachFiles 메서드를 단일화하여 saveNotice 및 updateNoticeFiles 에 중복 로직 없이 파일을 처리하도록 간소화 함
- NoticeFile 엔티티 설계 개선:
  createNoticeFile 팩토리 메서드를 통해 엔티티 생성 시 필수 경로 정보를 캡슐화하고 가독성을 높임
<br />

### 관련이슈
- 이슈 번호: #655 
- Closes: 공지사항 첨부파일 관련 전계층 리팩토링 작업 완료