### PR TITLE
결제주문번호 체계 간소화 및 파일 업로드 UI 개

### DIFF
--- a/clean4u/src/main/java/org/example/clean4u/payment/PaymentService.java
+++ b/clean4u/src/main/java/org/example/clean4u/payment/PaymentService.java
@@ -154,7 +154,7 @@ public class PaymentService {
     }
 
     private String generateMerchantUid(Long orderId) {
-        return "order_" + orderId + "_" + System.currentTimeMillis() + "_" + UUID.randomUUID().toString().substring(0, 8);
+        return "order_" + orderId + "_" + UUID.randomUUID().toString().substring(0, 8);
     }
 
     public PageResponse<PaymentResponse.ListDTO> paymentList(int page, int size, PaymentRequest.SearchDTO searchDTO) {

--- a/clean4u/src/main/resources/static/css/order.css
+++ b/clean4u/src/main/resources/static/css/order.css
@@ -121,6 +121,13 @@ input.has-value {
     background: var(--color-blue);
     cursor: pointer;
     font-size: 0.85rem;
+    flex-shrink: 0;
+}
+
+.image-row {
+    flex-grow: 1;
+    display: flex;
+    align-items: center;
 }
 
 .laundry-add {
@@ -543,12 +550,14 @@ input.has-value {
     border-radius: 10px;
     color: var(--color-gray);
     width: 100%;
-    max-width: 500px;
+    max-width: 100%;
     display: inline-block;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     padding: 0.5rem 0.7rem;
+    flex: 1;
+    margin-left: 0.7rem;
 }
 
 .status-badge.status-refund {

--- a/clean4u/src/main/resources/templates/order/save-form.mustache
+++ b/clean4u/src/main/resources/templates/order/save-form.mustache
@@ -44,17 +44,20 @@
                                placeholder="메모를 입력하세요(선택)" class="update-value">
                     </div>
                     <div class="update-item last">
-                        <label class="update-label">
+                        <label class="update-label" style="flex-shrink: 0; width: 100px;">
                             <i class="fa-solid fa-image"></i>
                             사진 추가
                         </label>
                         <input type="file" id="laundryImage" name="laundryImage" accept="image/*" hidden>
-                        <label for="laundryImage" class="btn image-add">
-                            <span id="imageLabel">
-                                <i class="fa-solid fa-upload"></i>
-                                파일 선택</span>
-                        </label>
-                        <span id="fileName" class="image-label"> 선택된 파일 없음</span>
+                        <div class="image-row">
+                            <label for="laundryImage" class="btn image-add">
+                                <span id="imageLabel">
+                                    <i class="fa-solid fa-upload"></i>
+                                    파일 선택
+                                </span>
+                            </label>
+                            <span id="fileName" class="image-label"> 선택된 파일 없음</span>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
### 작업 개요
- 주문 번호(Order ID)의 가독성을 높이기 위해 명명 규칙을 간소화하고, 파일 업로드 컴포넌트에서 발생하던 레이아웃 정렬 이슈를 해결했습니다.

### 주요 변경 사항
1. 주문 번호 생성 로직 변경
기존의 주문 번호 형식이 불필요하게 길어 가독성이 떨어지는 문제를 해결했습니다.

기존: order_(order_id)_System.now_UUID
변경: order_(order_id)_UUID

변경 사유: 고유성(UUID)은 유지하되, 타임스탬프(System.now)를 제거하여 문자열 길이를 단축하고 관리 효율성 증대

2. 파일 업로드 UI 레이아웃 최적화 (버그 수정)
화면 너비에 따라 "선택된 파일 없음" 영역이 충분히 확장되지 않거나 정렬이 어긋나던 문제를 수정했습니다.

수정 내용:
파일명 표시 영역(#fileName)에 flex-grow: 1을 적용하여 화면 우측 끝까지 확장되도록 개선

### UI 변경 결과 (AS-IS / TO-BE)
AS-IS: 화면 확장 시 파일명 칸이 늘어나지 않음, 레이블 간격 불균형
TO-BE: 화면 너비에 반응하여 파일명 칸이 유연하게 확장됨, 전체적인 가로 정렬 일치

### 관련 코드 영역
Backend: PaymentService 내 generateMerchantUid 메서드
Frontend: update-item 관련 CSS 및 HTML 구조