### PR TITLE
FE: summernote 글머리 기호 수정

### DIFF
--- a/clean4u/src/main/resources/static/css/notice-summernote.css
+++ b/clean4u/src/main/resources/static/css/notice-summernote.css
@@ -1,6 +1,14 @@
 .note-editable {
     font-size: 18px;
 }
+.note-editable ul {
+    list-style: disc;
+    padding-left: 1rem;
+}
+.note-editable ol {
+    list-style: decimal;
+    padding-left: 1rem;
+}
 
 .note-modal-body {
     background: var(--background-blue);

--- a/clean4u/src/main/resources/static/css/notice.css
+++ b/clean4u/src/main/resources/static/css/notice.css
@@ -548,11 +548,7 @@
     display: flex;
     flex-direction: column;
     flex: 1;
-}
-
-.file-item {
-    display: flex;
-    align-items: center;
+    gap: 0.5rem;
 }
 
 .new-file-label:not(:last-child) {

--- a/clean4u/src/main/resources/static/css/notice.css
+++ b/clean4u/src/main/resources/static/css/notice.css
@@ -313,6 +313,15 @@
     word-break: break-word;
 }
 
+.detail-value.content ul{
+    list-style: revert;
+    padding-left: 1rem;
+}
+.detail-value.content ol {
+    list-style: revert;
+    padding-left: 1rem;
+}
+
 .detail-notice-body {
     padding: 1rem 1.5rem 1.25rem;
     display: flex;
@@ -375,8 +384,31 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1rem;
-    text-align: center;
+    gap: 1.5rem;
+    font-size: 1.1rem;
+}
+
+.notice-text-wrapper {
+    width: 100%;
+    text-align: left;
+}
+.notice-text-wrapper p{
+    margin: 0;
+    line-height: 1.5;
+}
+.notice-text-wrapper ul {
+    list-style: disc;
+    padding-left: 1rem;
+    margin: 0.5rem 0;
+}
+.notice-text-wrapper ol {
+    list-style: decimal;
+    padding-left: 1rem;
+    margin: 0.5rem 0;
+}
+.notice-text-wrapper li {
+    list-style: inherit;
+    line-height: 1.5;
 }
 
 .notice-detail-item i {
@@ -515,13 +547,16 @@
 .file-list {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
     flex: 1;
 }
 
 .file-item {
     display: flex;
     align-items: center;
+}
+
+.new-file-label:not(:last-child) {
+    margin-bottom: 0.5rem;
 }
 
 .image-label-file {

--- a/clean4u/src/main/resources/static/js/notice/notice-file.js
+++ b/clean4u/src/main/resources/static/js/notice/notice-file.js
@@ -16,7 +16,6 @@ fileInput.addEventListener("change", function () {
     Array.from(files).forEach(file => {
         const div = document.createElement("div");
         div.classList.add("image-label-file", "new-file-label")
-        div.style.marginBottom = "8px";
         div.style.color = "blue";
         div.innerHTML = `${file.name}<i class="fa-solid fa-x remove-file" style=""></i>`;
         newFile.appendChild(div);

--- a/clean4u/src/main/resources/templates/notice/detail-form.mustache
+++ b/clean4u/src/main/resources/templates/notice/detail-form.mustache
@@ -59,7 +59,7 @@
                     </span>
                     <div class="detail-value-file">
                         {{#notice.attachments}}
-                        <div class="file-item image-label">
+                        <div class="image-label">
                             <i class="fa-solid fa-paperclip"></i>
                             <a href="/api/v1/files/{{fileId}}">
                                 {{originalName}}

--- a/clean4u/src/main/resources/templates/notice/detail-form.mustache
+++ b/clean4u/src/main/resources/templates/notice/detail-form.mustache
@@ -48,7 +48,9 @@
                 </div>
                 <div class="notice-detail-item">
                     <i class="fa-solid fa-message"></i>
-                    <p class="detail-value content">{{{notice.content}}}</p>
+                    <div class="notice-text-wrapper">
+                        <p class="detail-value content content-area">{{{notice.content}}}</p>
+                    </div>
                 </div>
                 <div class="detail-item last">
                     <span class="detail-label">
@@ -97,6 +99,5 @@
 </div>
 
 {{> layout/footer}}
-
 
 <script src="/js/notice/delete.js"></script>

--- a/clean4u/src/main/resources/templates/notice/update-form.mustache
+++ b/clean4u/src/main/resources/templates/notice/update-form.mustache
@@ -37,15 +37,15 @@
                             <div class="file-list" id="fileList">
                                 <input type="hidden" name="deleteFileIds" id="deleteFileIds">
                             {{#notice.attachments}}
-                                <span class="image-label-file" data-file-id="{{fileId}}">{{originalName}}
+                                <div class="image-label-file" data-file-id="{{fileId}}">{{originalName}}
                                     <i class="fa-solid fa-x remove-file"></i>
-                                </span>
+                                </div>
                             {{/notice.attachments}}
-                                <span id="newFile"></span>
-                                <span id="noFile" class="image-label"
+                                <div id="newFile"></div>
+                                <div id="noFile" class="image-label"
                                       style="{{#notice.attachments}}display:none;{{/notice.attachments}}
                                               {{^notice.attachments}}display:block;{{/notice.attachments}}"
-                                > 첨부파일 없음 </span>
+                                > 첨부파일 없음 </div>
                             </div>
                     </div>
                 </div>


### PR DESCRIPTION
summernote 웹 에디터의 글머리 기호가 base.css에 있는 list-style: none으로 인해
공지사항 생성 수정 detail 부분에서 보이지 않아 이를 css로 수정함.

또한, 파일 생성 수정 시의 JS의 css 부분은 notice.css로 이동하며 필요없는 css 제거 및 수정